### PR TITLE
updated schema for meta, keeping only specific meta nodes

### DIFF
--- a/intervention_graph_creation/src/local_graph_extraction/core.py
+++ b/intervention_graph_creation/src/local_graph_extraction/core.py
@@ -80,6 +80,21 @@ class Edge(BaseModel):
         if self.source_node == self.target_node:
             raise ValueError("self-loop edges are not allowed (source_node == target_node)")
         return self
+    
+
+class Meta(BaseModel):
+    key: str = Field(min_length=1, max_length=64, description="metadata key")
+    value: str = Field(min_length=1, max_length=256, description="metadata value")
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("key", "value")
+    @classmethod
+    def _strip_nonempty(cls, v: str) -> str:
+        v2 = v.strip()
+        if not v2:
+            raise ValueError("must be non-empty")
+        return v2
 
 
 class LogicalChain(BaseModel):
@@ -91,4 +106,5 @@ class LogicalChain(BaseModel):
 class PaperSchema(BaseModel):
     nodes: List[Node] = Field(default_factory=list)
     logical_chains: List[LogicalChain] = Field(default_factory=list)
+    meta: List[Meta] = Field(default_factory=list)
     model_config = ConfigDict(extra="forbid")

--- a/intervention_graph_creation/src/local_graph_extraction/extract/extract_test.py
+++ b/intervention_graph_creation/src/local_graph_extraction/extract/extract_test.py
@@ -11,5 +11,5 @@ INPUT_PDF_DIR = Path('intervention_graph_creation/data/raw/pdfs_local')
 extractor = Extractor()
 
 # extractor.process_jsonl(INPUT_JSON_FILE)
-extractor.process_dir(INPUT_JSON_DIR, 2)
+extractor.process_dir(INPUT_JSON_DIR)
 # extractor.process_dir(INPUT_PDF_DIR, 2)

--- a/intervention_graph_creation/src/local_graph_extraction/extract/extractor.py
+++ b/intervention_graph_creation/src/local_graph_extraction/extract/extractor.py
@@ -24,7 +24,7 @@ from intervention_graph_creation.src.local_graph_extraction.extract.utilities im
 MODEL = "o3"
 REASONING_EFFORT = "medium"
 SETTINGS = load_settings()
-META_KEYS = {'authors', 'date_published', 'filename', 'source', 'source_filetype', 'title', 'url'}
+META_KEYS = frozenset(['authors', 'date_published', 'filename', 'source', 'source_filetype', 'title', 'url'])
 
 
 class Extractor:

--- a/intervention_graph_creation/src/local_graph_extraction/extract/extractor.py
+++ b/intervention_graph_creation/src/local_graph_extraction/extract/extractor.py
@@ -15,7 +15,8 @@ from intervention_graph_creation.src.local_graph_extraction.extract.utilities im
                                                                                       stringify_response,
                                                                                       extract_output_text,
                                                                                       write_failure,
-                                                                                      url_to_id)
+                                                                                      url_to_id,
+                                                                                      filter_dict)
 
 # ---------------- Basic config ----------------
 
@@ -23,6 +24,7 @@ from intervention_graph_creation.src.local_graph_extraction.extract.utilities im
 MODEL = "o3"
 REASONING_EFFORT = "medium"
 SETTINGS = load_settings()
+META_KEYS = {'authors', 'date_published', 'filename', 'source', 'source_filetype', 'title', 'url'}
 
 
 class Extractor:
@@ -119,7 +121,7 @@ class Extractor:
 
         file_id = self.upload_pdf_get_id(path)
         resp = self.call_openai_file(file_id)
-        meta = {"filename": path.name} # other meta?
+        meta = [{"key": "filename", "value": path.name}] # other meta?
 
         self.write_outputs(out_dir, path.stem, resp, meta)
 
@@ -139,7 +141,7 @@ class Extractor:
                     out_dir.mkdir(parents=True, exist_ok=True)
 
                     resp = self.call_openai_text(paper_json['text'])
-                    meta = {k: paper_json[k] for k in paper_json if k != 'text'}
+                    meta = filter_dict(paper_json, META_KEYS)
 
                     self.write_outputs(out_dir, paper_id, resp, meta)
 

--- a/intervention_graph_creation/src/local_graph_extraction/extract/utilities.py
+++ b/intervention_graph_creation/src/local_graph_extraction/extract/utilities.py
@@ -15,6 +15,14 @@ def extract_output_text(resp: Any) -> str:
     return value if isinstance(value, str) else str(value or "")
 
 
+def filter_dict(d: dict, keys: set) -> list[dict]:
+    """
+    Return a flat list of {"key": key, "value": value}
+    for the specified keys that exist in the original dict.
+    """
+    return [{"key": k, "value": d[k]} for k in keys if k in d]
+
+
 def safe_write(path: Path, content: str) -> None:
     """Create parents (if needed) and write UTF-8 text."""
     path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
**Metadata model and schema updates:**

* Added a new `Meta` Pydantic model in `core.py` to represent metadata entries as key-value pairs with validation for non-empty, trimmed strings.
* Updated the `PaperSchema` model to include a `meta` field, which is a list of `Meta` objects, enforcing structured metadata at the schema level.

**Extraction logic improvements:**

* Modified the metadata extraction in `extractor.py` to use the new `Meta` format, including filtering relevant keys from JSONL input and formatting metadata as a list of key-value dicts. [[1]](diffhunk://#diff-b4942e4c71511df4a63fc6ee04f41bffeb22b8033c7586f767cef1508cf3da9aL122-R124) [[2]](diffhunk://#diff-b4942e4c71511df4a63fc6ee04f41bffeb22b8033c7586f767cef1508cf3da9aL142-R144)
* Added a `META_KEYS` constant to define which metadata fields to extract from input documents.

**Utility function enhancement:**

* Introduced a `filter_dict` utility function in `utilities.py` to convert a dictionary into a list of `{"key", "value"}` pairs for specified keys, supporting the new metadata structure.