### PR TITLE
add metadata to nodes and edges; trial on push to falkorDB

### DIFF
--- a/intervention_graph_creation/src/local_graph_extraction/core.py
+++ b/intervention_graph_creation/src/local_graph_extraction/core.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Literal
+from typing import List, Optional, Literal, Any
 from pydantic import BaseModel, Field, ConfigDict, field_validator, model_validator
 
 
@@ -14,6 +14,7 @@ class Node(BaseModel):
                                                   description="1-6 (only for intervention nodes)")
     intervention_maturity: Optional[int] = Field(default=None, ge=1, le=4,
                                                  description="1-4 (only for intervention nodes)")
+    meta: Optional[List['Meta']] = Field(default_factory=list, description="metadata key/value pairs for this node")
 
     model_config = ConfigDict(extra="forbid")
 
@@ -64,6 +65,7 @@ class Edge(BaseModel):
     target_node: str = Field(min_length=1, description="target node name")
     description: str = Field(min_length=1, description="concise description of logical connection")
     edge_confidence: int = Field(ge=1, le=5, description="1-5")
+    meta: Optional[List['Meta']] = Field(default_factory=list, description="metadata key/value pairs for this edge")
 
     model_config = ConfigDict(extra="forbid")
 
@@ -84,13 +86,13 @@ class Edge(BaseModel):
 
 class Meta(BaseModel):
     key: str = Field(min_length=1, max_length=64, description="metadata key")
-    value: str = Field(min_length=1, max_length=256, description="metadata value")
+    value: Any = Field(description="metadata value (string, number, bool, or array)")
 
     model_config = ConfigDict(extra="forbid")
 
-    @field_validator("key", "value")
+    @field_validator("key")
     @classmethod
-    def _strip_nonempty(cls, v: str) -> str:
+    def _strip_nonempty_key(cls, v: str) -> str:
         v2 = v.strip()
         if not v2:
             raise ValueError("must be non-empty")

--- a/intervention_graph_creation/src/local_graph_extraction/db/helpers.py
+++ b/intervention_graph_creation/src/local_graph_extraction/db/helpers.py
@@ -7,6 +7,11 @@ def lit(v):
         return "'" + v.replace("\\", "\\\\").replace("'", "\\'") + "'"
     if isinstance(v, (list, tuple)):
         return "[" + ", ".join(lit(x) for x in v) + "]"
+    if isinstance(v, dict):
+        items = []
+        for k, val in v.items():
+            items.append(f"{k}: {lit(val)}")
+        return "{" + ", ".join(items) + "}"
     return "'" + str(v).replace("\\", "\\\\").replace("'", "\\'") + "'"
 
 

--- a/intervention_graph_creation/src/local_graph_extraction/extract/extract_test.py
+++ b/intervention_graph_creation/src/local_graph_extraction/extract/extract_test.py
@@ -2,7 +2,7 @@ import os
 import json
 from pathlib import Path
 
-from extractor import Extractor
+from .extractor import Extractor
 
 INPUT_JSON_FILE = Path('intervention_graph_creation/data/raw/ard_json_test/agentmodels.jsonl')
 INPUT_JSON_DIR = Path('intervention_graph_creation/data/raw/ard_json_test')


### PR DESCRIPTION
## Metadata at LocalGraph
- For output JSON, we store meta only at the paper level (not duplicating it into nodes and edges); But in FalkorDB, we'll have metadata inserted into each node and edge to enable filtering by some metadata attributes, e.g., source.
- Added some logging and exception handling 

Example on filter w.r.t source
<img width="1108" height="635" alt="image" src="https://github.com/user-attachments/assets/e424e47e-a746-4e25-a82e-f21cbbc4f552" />
