### PR TITLE
Semantic compression part 2

### DIFF
--- a/config.py
+++ b/config.py
@@ -52,6 +52,8 @@ def load_settings(config_path: Path | None = None) -> Settings:
         paths=Paths(
             input_dir=rel(paths_cfg.get("input_dir", "./intervention_graph_creation/data/raw/pdfs_local")),
             output_dir=rel(paths_cfg.get("output_dir", "./intervention_graph_creation/data/processed")),
+            # for testing on subset of data:
+            # output_dir=rel(paths_cfg.get("output_dir", "./intervention_graph_creation/data/copy")),
         ),
         falkordb=FalkorDB(
             host=falkor_cfg.get("host", "localhost"),

--- a/intervention_graph_creation/src/local_graph_extraction/core/edge.py
+++ b/intervention_graph_creation/src/local_graph_extraction/core/edge.py
@@ -32,6 +32,9 @@ class GraphEdge(Edge):
     embedding: Optional[np.ndarray] = None
     logical_chain_title: Optional[str] = None  # Equivalent to title in LogicalChain
     model_config = ConfigDict(arbitrary_types_allowed=True)
+    is_tombstone: Optional[bool] = False
+    merge_rationale: Optional[str] = None
+    cycle_id: Optional[str] = None
 
     def __init__(self, **data):
         # Handle embedding separately to avoid pydantic validation issues

--- a/intervention_graph_creation/src/local_graph_extraction/core/edge.py
+++ b/intervention_graph_creation/src/local_graph_extraction/core/edge.py
@@ -1,6 +1,7 @@
 from typing import Optional
 from pydantic import BaseModel, Field, ConfigDict, field_validator, model_validator
 import numpy as np
+import time
 
 
 class Edge(BaseModel):
@@ -32,9 +33,12 @@ class GraphEdge(Edge):
     embedding: Optional[np.ndarray] = None
     logical_chain_title: Optional[str] = None  # Equivalent to title in LogicalChain
     model_config = ConfigDict(arbitrary_types_allowed=True)
-    is_tombstone: Optional[bool] = False
-    merge_rationale: Optional[str] = None
-    cycle_id: Optional[str] = None
+    # semantic compression
+    is_tombstone: Optional[bool] =  False
+    merge_rational: Optional[str] = None
+    cycled_id: Optional[str] = None
+    created_at: Optional[int] = None
+    updated_at: Optional[int] = None
 
     def __init__(self, **data):
         # Handle embedding separately to avoid pydantic validation issues
@@ -42,4 +46,6 @@ class GraphEdge(Edge):
         logical_chain_title = data.pop('logical_chain_title', None)
         super().__init__(**data)
         self.embedding = embedding
+        self.created_at = int(time.time() * 1000)
+        self.updated_at = int(time.time() * 1000)
         self.logical_chain_title = logical_chain_title

--- a/intervention_graph_creation/src/local_graph_extraction/core/node.py
+++ b/intervention_graph_creation/src/local_graph_extraction/core/node.py
@@ -63,6 +63,9 @@ class GraphNode(Node):
     """Extended Node class with embedding support."""
     embedding: Optional[np.ndarray] = None
     model_config = ConfigDict(arbitrary_types_allowed=True)
+    is_tombstone: Optional[bool] = False
+    is_leaf: Optional[bool] = True
+    cycle_id: Optional[str] = None
 
     def __init__(self, **data):
         # Handle embedding separately to avoid pydantic validation issues

--- a/intervention_graph_creation/src/local_graph_extraction/core/node.py
+++ b/intervention_graph_creation/src/local_graph_extraction/core/node.py
@@ -1,6 +1,7 @@
-from typing import Optional, Literal, List
+from typing import Optional, Literal, List, Dict
 from pydantic import BaseModel, Field, ConfigDict, field_validator, model_validator
 import numpy as np
+import time
 
 
 class Node(BaseModel):
@@ -63,12 +64,16 @@ class GraphNode(Node):
     """Extended Node class with embedding support."""
     embedding: Optional[np.ndarray] = None
     model_config = ConfigDict(arbitrary_types_allowed=True)
-    is_tombstone: Optional[bool] = False
+    is_tombstone: Optional[bool] =  False
     is_leaf: Optional[bool] = True
-    cycle_id: Optional[str] = None
+    cycled_id: Optional[str] = None
+    created_at: Optional[int] = None
+    updated_at: Optional[int] = None
 
     def __init__(self, **data):
         # Handle embedding separately to avoid pydantic validation issues
         embedding = data.pop('embedding', None)
         super().__init__(**data)
+        self.created_at = int(time.time() * 1000)
+        self.updated_at = int(time.time() * 1000)
         self.embedding = embedding

--- a/semantic_compression_part_2.py
+++ b/semantic_compression_part_2.py
@@ -1,0 +1,105 @@
+#TODO rename file and move to appropriate location
+from falkordb import FalkorDB, Graph, Path
+
+from typing import List, Set
+from config import load_settings
+
+SETTINGS = load_settings()
+
+
+class MergeSet:
+    """
+    A set of node IDs to be merged, along with a rationale for the merge decision.
+    Each MergeSet should contain at least two node IDs.
+    Each node ID should be unique across all MergeSets, ensuring no node ID appears in more than one set.
+    """
+    nodes: Set[int]
+    rationale: str
+
+def merge_judge(context: str) -> List[MergeSet]:
+    """ 
+    A placeholder function for the merge judge logic. Ie a judge who decides which nodes to merge
+    and provides a merge rationale.
+    # TODO get in contact with Mitali and integrate her merge judge code from her pull request
+    """
+    # TODO implement merge judge from Mitali's PR
+    return []
+
+def get_context_for_merge_judge(cluster_paths: List[List[Path]]) -> str:
+    """
+    Given a list of paths representing the context of a cluster of similar nodes,
+    generate a textual context to be provided to the merge judge.
+
+    Each path contains nodes and edges, which can be used to extract relevant information.
+    """
+    # TODO implement context extraction logic from Mitali's PR
+    return ""
+
+# https://github.com/MartinLeitgab/AISafetyIntervention_LiteratureExtraction/issues/100
+# For each set of very similar nodes execute the following steps
+def compress_cluster(g: Graph, cluster_nodes: List[int]):
+    # Use vlr to find only the directly connected nodes
+    # https://docs.falkordb.com/cypher/match#variable-length-relationships
+    # 0 is the minimum length (include the node itself if it has no edges)
+    # 1 is the maximum length (only directly connected nodes)
+
+    # and use bidirectional path traversal
+    # to find all connected nodes regardless of which is source or target
+    # https://docs.falkordb.com/cypher/match.html#bidirectional-path-traversal
+
+    cypher_query = """
+    // Find all paths between nodes (non-tombstone) in the cluster with length 0 or 1
+    // the search is bidirectional
+    MATCH p=(n:NODE {is_tombstone:false})-[:EDGE*0..1 {is_tombstone:false}]-(m:NODE {is_tombstone:false})
+    // id of n must be in the cluster
+    WHERE id(n) IN $cluster
+      AND (
+        // if path length is 0, n is isolated, include it
+        (length(p) = 0 AND NOT (n)-[:EDGE {is_tombstone:false}]-())
+        OR
+        // if path length is 1, include only if m is not in cluster or to avoid duplicates
+        // this way a path between two nodes in the cluster is only included once
+        (length(p) = 1 AND (NOT id(m) IN $cluster OR id(n) < id(m)))
+      )
+    RETURN p
+    """
+    result = g.query(cypher_query, {"cluster": cluster_nodes})
+    # now results should return 1 path for each edge between nodes in the cluster
+    # and 1 path for each isolated node in the cluster
+
+
+    #Pass the information and an appropriate compression prompt (to be developed) to the compression LLM for combining of the set (creates one or more parent nodes from nodes in the set and returns JSON, with data structure as laid out in @MartinLeitgab 's comment to @ArdhitoN 's PR LLM-assisted Graph-Merging - Step 1 - data-only LLM input prep for node comparisons eamag/AISafetyIntervention_LiteratureExtraction#1 (comment)). (maybe partially implemented
+    context = get_context_for_merge_judge(result.result_set)
+    merge_sets = merge_judge(context)
+
+
+
+    # Now, for each MergeSet, perform the merge operation in the graph
+    for merge_set in merge_sets:
+        # Extract node and edge information
+        nodes = merge_set.nodes
+        rationale = merge_set.rationale
+        # TODO
+
+    # TODO Write post-merging parent node back into DB, e.g. setting tombstone flags on raw nodes that have been merged so that only the merged node is used in future queries, and keeping info of merged raw nodes store parent nodes with lists of edges/pointers to their child nodes (TBD code, maybe not implemented yet- see @jonpsy ’s suggestion in Issue [Story 4/5] Integrating database-driven approach for supernodes and superedges #35 )
+
+
+# TODO Things to test in unit tests:
+# - Test that all nodes in the cluster are included
+# - Test that all edges between the nodes in the cluster are included
+# - Test that multihop doesn't happen, only direct connections are found
+# - Test that tombstone nodes and edges are not included
+# - Test that isolated nodes (no edges) are included
+# - Test that if both nodes in an edge are in the cluster, the edge is included only once
+if __name__ == "__main__":
+
+    db = FalkorDB(host=SETTINGS.falkordb.host, port=SETTINGS.falkordb.port)
+    
+    g = db.select_graph(SETTINGS.falkordb.graph)
+
+
+    # Example cluster of similar node IDs
+    example_cluster = [1, 2, 3, 133]
+    
+    # Compress the cluster
+    compress_cluster(g, example_cluster)


### PR DESCRIPTION
In progress PR of Semantic compression part 2 (#100). So far, it implements efficient querying of
> For each node in the set, collect all edge information and all immediate neighbor nodes information (only nodes of neighbors, not all edges of neighbors except the one connecting back to the node in the set here) @ArdhitoN 's code, @jonpsy ’s suggestion in Issue https://github.com/MartinLeitgab/AISafetyIntervention_LiteratureExtraction/issues/35

via

```python
   # Use vlr to find only the directly connected nodes
    # https://docs.falkordb.com/cypher/match#variable-length-relationships
    # 0 is the minimum length (include the node itself if it has no edges)
    # 1 is the maximum length (only directly connected nodes)

    # and use bidirectional path traversal
    # to find all connected nodes regardless of which is source or target
    # https://docs.falkordb.com/cypher/match.html#bidirectional-path-traversal
 cypher_query = """
    // Find all paths between nodes (non-tombstone) in the cluster with length 0 or 1
    // the search is bidirectional
    MATCH p=(n:NODE {is_tombstone:false})-[:EDGE*0..1 {is_tombstone:false}]-(m:NODE {is_tombstone:false})
    // id of n must be in the cluster
    WHERE id(n) IN $cluster
      AND (
        // if path length is 0, n is isolated, include it
        (length(p) = 0 AND NOT (n)-[:EDGE {is_tombstone:false}]-())
        OR
        // if path length is 1, include only if m is not in cluster or to avoid duplicates
        // this way a path between two nodes in the cluster is only included once
        (length(p) = 1 AND (NOT id(m) IN $cluster OR id(n) < id(m)))
      )
    RETURN p
    """
    result = g.query(cypher_query, {"cluster": cluster_nodes})
 ```
 
 TODO
 - [ ] integrate @Hacxmr's PR #97 for part ii
 - [ ] part iii