### PR TITLE
Fix variable reference for source_url in query

### DIFF
--- a/intervention_graph_creation/src/local_graph_extraction/db/ai_safety_graph.py
+++ b/intervention_graph_creation/src/local_graph_extraction/db/ai_safety_graph.py
@@ -54,7 +54,7 @@ class AISafetyGraph:
             n.url = $url
         WITH n, $embedding AS emb, $url AS source_url
         SET n.embedding = CASE WHEN emb IS NULL THEN NULL ELSE vecf32(emb) END
-        WITH n, source_url
+        WITH n, $url AS source_url
         MERGE (p:Source {{url: source_url}})
         MERGE (n)-[:FROM]->(p)
         RETURN n


### PR DESCRIPTION
one line fix.
Fixes error: `redis.exceptions.ResponseError: 'source_url' not defined`