### PR TITLE
What the 70% collapse drops, and what the release actually ships (#157)

### DIFF
--- a/graph_analysis/experiment_review_containment_semantics.py
+++ b/graph_analysis/experiment_review_containment_semantics.py
@@ -1,0 +1,398 @@
+#!/usr/bin/env python
+"""What exactly does the 70% sub-path collapse drop, in terms a reader can check?
+
+Reviewers of the 2026-08-15 round raised the same objection twice: the containment rule
+compares NODE SETS, so it is blind to edge identity, to order, and to whether the dropped
+traversal is an argument the kept one does not carry. The paper answers with two numbers
+(78.3% of dropped paths carry a novel node; 6.1% of chain-set nodes survive in no kept
+chain) and concedes the step is not lossless. Neither number says whether a dropped path
+was already traced by its container.
+
+This script re-implements the collapse exactly as phase1_dedup_paths.py ran it -- greedy,
+longest-first, threshold 0.70, within source paper -- asserts it reproduces the released
+2,772/8,954 split before reporting anything, then records for every dropped path WHICH kept
+path displaced it and how the two relate:
+
+  * node-set relation      -- is the dropped path's node set a subset of its container's?
+  * order                  -- is the dropped node sequence a contiguous sub-path of the
+                              container, a non-contiguous subsequence, or neither?
+  * edge identity          -- is every consecutive pair the dropped path traverses also
+                              consecutive in the container? If not, the dropped path walks
+                              a relation the container never walks, which is precisely what
+                              a node-set rule cannot see.
+  * relation semantics     -- the edge subtypes on those unmatched hops, and whether the
+                              released graph carries parallel edges (same node pair, two
+                              relation types) at all.
+  * stage coverage         -- do the dropped path's novel nodes introduce a logical-chain
+                              stage the container lacks?
+
+Class B (no LLM call, no network). Run from graph_analysis/:
+
+    python -u experiment_review_containment_semantics.py
+
+Output: graph_analysis/phase2_results/experiment_review_containment_semantics_report.json
+
+What this cannot do: decide whether two traversals are the same ARGUMENT. That is an
+annotation question (OPEN_ITEMS.md S4/R23). It bounds the question from below -- a dropped
+path that is a contiguous sub-path of its container, over the same edges, is a restatement
+by construction, and the rest are where an annotator would have to look.
+"""
+
+import json
+import pickle
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+ROOT = Path(__file__).parent
+SLIM = ROOT / "phase2_results/node_attrs_slim.pkl"
+EDGES = (
+    ROOT
+    / "phase2_results/step1_load_and_parse_umapwithoutlocalsatellites/graph_edge_data.pkl"
+)
+RAW = ROOT / "phase1_rawpathsfiles/paths_hopwise_v4_edge_only.jsonl"
+DEDUPED = ROOT / "phase1_rawpathsfiles/paths_hopwise_v4_edge_only_deduped.jsonl"
+OUT = ROOT / "phase2_results/experiment_review_containment_semantics_report.json"
+
+CONTAINMENT_THRESHOLD = (
+    0.70  # phase1_dedup_paths.py: the code uses 0.70, docstring says 80%
+)
+EXPECTED_RAW, EXPECTED_KEPT = 8954, 2772
+
+STAGES = (
+    "risk",
+    "problem analysis",
+    "theoretical insight",
+    "design rationale",
+    "implementation mechanism",
+    "validation evidence",
+)
+
+
+def pct(n, d, nd=1):
+    return round(100 * n / d, nd) if d else None
+
+
+def load_paths(fp):
+    out = []
+    with open(fp, encoding="utf-8") as f:
+        for i, line in enumerate(f, 1):
+            line = line.strip()
+            if not line:
+                continue
+            d = json.loads(line)
+            d["path_id"] = f"path_{i:05d}"
+            out.append(d)
+    return out
+
+
+def is_contiguous_subpath(small, large):
+    n = len(small)
+    return any(large[i : i + n] == small for i in range(len(large) - n + 1))
+
+
+def is_subsequence(small, large):
+    it = iter(large)
+    return all(any(x == y for y in it) for x in small)
+
+
+def main():
+    for p, how in (
+        (SLIM, "run experiment_review_prep_slim_nodes.py"),
+        (EDGES, "run phase2_step1_loadandparse.py against the FalkorDB dump"),
+        (RAW, "the released 8,954-chain path file ships with the repo"),
+        (DEDUPED, "the released 2,772-chain path file ships with the repo"),
+    ):
+        if not p.exists():
+            raise SystemExit(f"FATAL: {p} not found. To produce it: {how}.")
+
+    slim = pickle.load(open(SLIM, "rb"))
+    url_of = {int(n): r.get("url") for n, r in slim.items()}
+    cat_of = {
+        int(n): (
+            r.get("concept_category") if r.get("type") == "concept" else "intervention"
+        )
+        for n, r in slim.items()
+    }
+
+    edges = pickle.load(open(EDGES, "rb"))
+    # Hop-wise enumeration walks structural edges without regard to direction: 94.1% of the
+    # hops in the released path file match an edge (source -> target) and 100% match one
+    # (source, target) unordered, so pairs are keyed unordered here. Keying them directed
+    # would report every reversed hop as an edge the graph does not contain.
+    subtypes_of_pair = defaultdict(set)
+    for e in edges:
+        if e.get("type") != "EDGE":
+            continue
+        subtypes_of_pair[frozenset((e["source"], e["target"]))].add(e.get("subtype"))
+    parallel_pairs = sum(1 for v in subtypes_of_pair.values() if len(v) > 1)
+
+    raw = load_paths(RAW)
+    deduped = load_paths(DEDUPED)
+    if len(raw) != EXPECTED_RAW:
+        raise SystemExit(
+            f"FATAL: raw path file has {len(raw)}, expected {EXPECTED_RAW}"
+        )
+
+    # ---- re-implement the collapse, recording the container of every drop ---------------
+    by_url = defaultdict(list)
+    for p in raw:
+        urls = {url_of.get(int(n)) for n in p["path"]}
+        urls.discard(None)
+        if len(urls) == 1:
+            by_url[next(iter(urls))].append(p)
+        elif not urls:
+            by_url[f"_orphan_{p['path_id']}"].append(p)
+        else:
+            by_url[f"_mixed_{p['path_id']}"].append(p)
+
+    keep, drops = set(), []
+    for _url, plist in by_url.items():
+        ordered = sorted(plist, key=lambda p: -len(p["path"]))
+        sets = [(p["path_id"], frozenset(p["path"])) for p in ordered]
+        for i, (pid_i, ns_i) in enumerate(sets):
+            if not ns_i:
+                drops.append((pid_i, None))
+                continue
+            container = None
+            for pid_j, ns_j in sets[:i]:
+                if pid_j not in keep or not ns_j:
+                    continue
+                small, large = (ns_i, ns_j) if len(ns_i) <= len(ns_j) else (ns_j, ns_i)
+                if len(small & large) / len(small) >= CONTAINMENT_THRESHOLD:
+                    container = pid_j
+                    break
+            if container is None:
+                keep.add(pid_i)
+            else:
+                drops.append((pid_i, container))
+
+    if len(keep) != EXPECTED_KEPT:
+        raise SystemExit(
+            f"FATAL: re-implementation kept {len(keep)}, released file has {EXPECTED_KEPT}. "
+            "The procedure below does not reproduce the released substrate; nothing here "
+            "is reportable until it does."
+        )
+    released_ids = {tuple(p["path"]) for p in deduped}
+    kept_ids = {tuple(p["path"]) for p in raw if p["path_id"] in keep}
+    if released_ids != kept_ids:
+        raise SystemExit(
+            "FATAL: re-implementation keeps a different SET of chains than the released "
+            f"file ({len(released_ids ^ kept_ids)} symmetric-difference members)."
+        )
+
+    path_of = {p["path_id"]: p["path"] for p in raw}
+
+    # ---- characterise every drop --------------------------------------------------------
+    rel = Counter()
+    order = Counter()
+    edge_id = Counter()
+    endpoint = Counter()
+    unmatched_hop_subtypes = Counter()
+    novel_stage = Counter()
+    shared_prefix_len = Counter()
+    n_novel_node = 0
+    empty_drops = 0
+
+    for pid, cid in drops:
+        if cid is None:
+            empty_drops += 1
+            continue
+        d, c = path_of[pid], path_of[cid]
+        ds, cs = set(d), set(c)
+
+        # Does the dropped chain propose an intervention the kept chain never reaches?
+        # This is the reviewers' question in the form the data can answer: a chain ending
+        # at a different remedy is a different risk-to-intervention claim, whatever the
+        # node-set overlap.
+        endpoint[
+            "ends_at_an_intervention_absent_from_the_container"
+            if d[-1] not in cs
+            else "ends_at_an_intervention_the_container_also_contains"
+        ] += 1
+
+        k = 0
+        for x, y in zip(d, c):
+            if x != y:
+                break
+            k += 1
+        shared_prefix_len[k] += 1
+
+        subset = ds <= cs
+        rel[
+            "node_set_is_subset_of_container" if subset else "partial_overlap_only"
+        ] += 1
+        if not subset:
+            n_novel_node += 1
+            novel = ds - cs
+            cont_stages = {cat_of.get(int(n)) for n in c}
+            if any(cat_of.get(int(n)) not in cont_stages for n in novel):
+                novel_stage["novel_node_introduces_a_stage_the_container_lacks"] += 1
+            else:
+                novel_stage[
+                    "novel_nodes_are_all_in_stages_the_container_already_has"
+                ] += 1
+
+        if is_contiguous_subpath(d, c):
+            order["contiguous_sub_path_of_container"] += 1
+        elif is_subsequence(d, c):
+            order["non_contiguous_subsequence"] += 1
+        else:
+            order["not_a_subsequence_reordered_or_branching"] += 1
+
+        chops = {frozenset(h) for h in zip(c, c[1:])}
+        dhops = [frozenset(h) for h in zip(d, d[1:])]
+        unmatched = [h for h in dhops if h not in chops]
+        if unmatched:
+            edge_id["traverses_at_least_one_hop_the_container_never_traverses"] += 1
+            # Not every unmatched hop is equal. A hop whose two endpoints both sit in the
+            # container is a chord -- the dropped path takes a direct relation across a node
+            # the container walks through, so the two trace the same material at different
+            # granularity. A hop touching a node the container lacks is a genuine departure.
+            if all(h <= cs for h in unmatched):
+                edge_id["unmatched_hops_are_all_chords_across_container_nodes"] += 1
+            else:
+                edge_id[
+                    "at_least_one_unmatched_hop_touches_a_node_the_container_lacks"
+                ] += 1
+            for h in unmatched:
+                for s in subtypes_of_pair.get(h, {"<absent from released EDGE set>"}):
+                    unmatched_hop_subtypes[s] += 1
+        else:
+            edge_id["every_hop_is_also_a_hop_of_the_container"] += 1
+
+    n_drops = len(drops)
+    strict = order["contiguous_sub_path_of_container"]
+
+    ri_raw = {(p["path"][0], p["path"][-1]) for p in raw}
+    ri_kept = {(p["path"][0], p["path"][-1]) for p in deduped}
+    lost_pairs = ri_raw - ri_kept
+
+    out = {
+        "experiment": "semantics of the 70% sub-path collapse (R22/R23)",
+        "question": (
+            "The containment rule compares node sets. Reviewers asked what it does to edge "
+            "identity, order, and to traversals that are arguments in their own right."
+        ),
+        "reproduction_check": {
+            "raw_paths": len(raw),
+            "kept": len(keep),
+            "dropped": n_drops,
+            "released_deduped_file": len(deduped),
+            "keeps_the_same_set_as_the_released_file": True,
+            "note": (
+                "The script exits non-zero unless the re-implementation reproduces the "
+                "released chain set exactly, so every number below describes the substrate "
+                "the paper reports on."
+            ),
+        },
+        "node_set_relation": {
+            **dict(rel),
+            "pct_subset": pct(rel["node_set_is_subset_of_container"], n_drops),
+            "pct_partial_overlap_only": pct(rel["partial_overlap_only"], n_drops),
+            "cross_check_novel_node_share_pct": pct(n_novel_node, n_drops),
+            "cross_check_note": (
+                "experiment_review_gate_sensitivity_report.json -> "
+                "containment_losslessness reports 78.3% of dropped paths carrying at least "
+                "one node their container lacks. That is the same quantity as "
+                "pct_partial_overlap_only and must agree."
+            ),
+        },
+        "order_relation": {
+            **dict(order),
+            "pct_contiguous_sub_path": pct(strict, n_drops),
+            "reading": (
+                "A contiguous sub-path over the same node order is a restatement by "
+                "construction: the container traces it and continues. Those drops are "
+                "unambiguously safe. Everything else is where an annotator would have to "
+                "decide, and that share is what the paper should state."
+            ),
+        },
+        "edge_identity": {
+            **dict(edge_id),
+            "pct_with_an_unmatched_hop": pct(
+                edge_id["traverses_at_least_one_hop_the_container_never_traverses"],
+                n_drops,
+            ),
+            "pct_chords_only": pct(
+                edge_id["unmatched_hops_are_all_chords_across_container_nodes"], n_drops
+            ),
+            "pct_touching_a_node_the_container_lacks": pct(
+                edge_id[
+                    "at_least_one_unmatched_hop_touches_a_node_the_container_lacks"
+                ],
+                n_drops,
+            ),
+            "unmatched_hop_relation_types": dict(unmatched_hop_subtypes.most_common()),
+            "reading": (
+                "This is the reviewers' objection made numeric, and it splits two ways. "
+                "Every dropped path traverses at least one relation its container does not, "
+                "so no drop is a strict re-walk. But where the unmatched hops are chords "
+                "across nodes the container also holds, the two chains trace the same "
+                "material at different granularity, and calling the drop a repeat is "
+                "defensible. The other class is a genuine departure."
+            ),
+        },
+        "does_the_drop_remove_a_distinct_remedy": {
+            **dict(endpoint),
+            "pct_ending_at_an_intervention_the_container_lacks": pct(
+                endpoint["ends_at_an_intervention_absent_from_the_container"], n_drops
+            ),
+            "distinct_risk_to_intervention_pairs_raw": len(ri_raw),
+            "distinct_risk_to_intervention_pairs_kept": len(ri_kept),
+            "distinct_pairs_lost_to_the_collapse": len(lost_pairs),
+            "pct_of_raw_pairs_lost": pct(len(lost_pairs), len(ri_raw)),
+            "reading": (
+                "This is the sharpest structural form of the reviewers' question. A dropped "
+                "chain that terminates at an intervention the kept chain never reaches "
+                "proposes a remedy the reporting unit no longer carries for that risk. The "
+                "pair counts must agree with experiment_paper_claim_audit.json -> "
+                "distinct_ri_node_pairs (raw 3,222 / deduped 2,643)."
+            ),
+        },
+        "shared_prefix_with_container": {
+            "length_histogram_nodes": {
+                str(k): v for k, v in sorted(shared_prefix_len.items())
+            },
+            "pct_sharing_the_risk_root": pct(
+                sum(v for k, v in shared_prefix_len.items() if k >= 1), n_drops
+            ),
+            "reading": (
+                "Enumeration is risk-rooted, so a shared prefix is expected; the length at "
+                "which two chains diverge is where one paper's argument branches."
+            ),
+        },
+        "novel_node_stage_coverage": dict(novel_stage),
+        "parallel_edges_in_the_released_graph": {
+            "node_pairs_carrying_more_than_one_relation_type": parallel_pairs,
+            "reading": (
+                "If this is zero, the collapse cannot conflate two different relations "
+                "between the same pair of nodes, and the edge-identity question reduces to "
+                "which node pairs are traversed."
+            ),
+        },
+        "empty_paths_dropped": empty_drops,
+        "HEADLINE": (
+            f"Of {n_drops} dropped paths, {pct(strict, n_drops)}% are contiguous sub-paths of "
+            f"the chain that displaced them; "
+            f"{pct(edge_id['traverses_at_least_one_hop_the_container_never_traverses'], n_drops)}% "
+            "traverse at least one relation the kept chain does not, and "
+            f"{pct(endpoint['ends_at_an_intervention_absent_from_the_container'], n_drops)}% "
+            f"end at an intervention the kept chain never reaches. {len(lost_pairs)} distinct "
+            f"risk-to-intervention pairs ({pct(len(lost_pairs), len(ri_raw))}% of the raw set) "
+            "are not represented in the reporting unit at all."
+        ),
+        "LIMITS": (
+            "Structural only. Two traversals over disjoint hops may still be the same "
+            "argument, and two over identical hops may be read differently. Settling that "
+            "needs the annotation study of OPEN_ITEMS.md S4."
+        ),
+    }
+
+    OUT.write_text(json.dumps(out, indent=1), encoding="utf-8")
+    print(json.dumps(out, indent=1))
+    print(f"\nwrote {OUT}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/graph_analysis/experiment_review_release_integrity.py
+++ b/graph_analysis/experiment_review_release_integrity.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python
+"""Does the released graph carry the defects the judge found, and can a reuser re-gate it?
+
+Three reviewer questions in the 2026-08-15 round have the same shape -- they ask what a
+person who downloads the release actually gets:
+
+  C8/R45  The judge reported 108 referential-integrity findings, 42 orphans and 56
+          duplicate node pairs across 100 papers, and no repaired graph was ever rebuilt.
+          Does the released dump ship those defects? The paper does not say.
+  R46     Users need a way to tell audited content from unaudited content.
+  R114    Can a reuser re-enumerate chains at any gate setting from the dump, or are they
+          restricted to consuming the two path files we ship?
+
+None of the three needs an inference call. This script measures them directly on the
+released substrate: orphan and dangling counts computed the same way the judge's classes
+are defined, the share of the graph that any judge ever looked at, and whether every
+attribute the two gates read is actually present on every node and edge that carries it.
+
+Class B (no LLM call, no network). Run from graph_analysis/:
+
+    python -u experiment_review_release_integrity.py --judge-reports <dir>
+
+<dir> is extraction_validator/extend_try_1 from branch anthropic_judge_test.
+
+Output: graph_analysis/phase2_results/experiment_review_release_integrity_report.json
+"""
+
+import argparse
+import json
+import pickle
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+ROOT = Path(__file__).parent
+SLIM = ROOT / "phase2_results/node_attrs_slim.pkl"
+EDGES = (
+    ROOT
+    / "phase2_results/step1_load_and_parse_umapwithoutlocalsatellites/graph_edge_data.pkl"
+)
+RAW = ROOT / "phase1_rawpathsfiles/paths_hopwise_v4_edge_only.jsonl"
+OUT = ROOT / "phase2_results/experiment_review_release_integrity_report.json"
+
+EXPECTED_NODES, EXPECTED_EDGE_EDGES = 200525, 202149
+NONE_STRINGS = {"None", "none", "", "null", "NULL"}
+
+
+def pct(n, d, nd=2):
+    return round(100 * n / d, nd) if d else None
+
+
+def present(v):
+    return v is not None and str(v).strip() not in NONE_STRINGS
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--judge-reports", required=True)
+    a = ap.parse_args()
+    jdir = Path(a.judge_reports)
+    if not jdir.is_dir():
+        raise SystemExit(
+            f"FATAL: judge report directory not found: {jdir}\n"
+            "  git archive origin/anthropic_judge_test extraction_validator/extend_try_1"
+            " | tar -x -C /tmp/judge"
+        )
+    for p, how in (
+        (SLIM, "run experiment_review_prep_slim_nodes.py"),
+        (EDGES, "run phase2_step1_loadandparse.py against the FalkorDB dump"),
+        (RAW, "the released 8,954-chain path file ships with the repo"),
+    ):
+        if not p.exists():
+            raise SystemExit(f"FATAL: {p} not found. To produce it: {how}.")
+
+    slim = pickle.load(open(SLIM, "rb"))
+    if len(slim) != EXPECTED_NODES:
+        raise SystemExit(
+            f"FATAL: node table has {len(slim)}, expected {EXPECTED_NODES}. Wrong substrate."
+        )
+    nodes = {int(n): r for n, r in slim.items()}
+    edges = pickle.load(open(EDGES, "rb"))
+
+    deg = Counter()
+    dangling = 0
+    self_loops = 0
+    edge_pair_subtype = Counter()
+    n_struct = 0
+    conf_missing = 0
+    subtype_missing = 0
+    for e in edges:
+        if e.get("type") != "EDGE":
+            continue
+        n_struct += 1
+        s, t = e["source"], e["target"]
+        if s not in nodes or t not in nodes:
+            dangling += 1
+            continue
+        if s == t:
+            self_loops += 1
+        deg[s] += 1
+        deg[t] += 1
+        edge_pair_subtype[(frozenset((s, t)), e.get("subtype"))] += 1
+        if not present(e.get("confidence")):
+            conf_missing += 1
+        if not present(e.get("subtype")):
+            subtype_missing += 1
+
+    if n_struct != EXPECTED_EDGE_EDGES:
+        raise SystemExit(
+            f"FATAL: {n_struct} EDGE-type edges, expected {EXPECTED_EDGE_EDGES}."
+        )
+
+    orphans = [n for n in nodes if deg[n] == 0]
+    dup_edges = sum(v - 1 for v in edge_pair_subtype.values() if v > 1)
+
+    # exact-name duplicates within concept category (the residue app:composition reports)
+    by_name = defaultdict(list)
+    for n, r in nodes.items():
+        key = (
+            (r.get("name") or "").strip().lower(),
+            r.get("concept_category") if r.get("type") == "concept" else "intervention",
+        )
+        if key[0]:
+            by_name[key].append(n)
+    dup_groups = {k: v for k, v in by_name.items() if len(v) > 1}
+    dup_nodes_beyond_one = sum(len(v) - 1 for v in dup_groups.values())
+
+    # can a reuser re-gate? both gate attributes must be present wherever they are read
+    interventions = [n for n, r in nodes.items() if r.get("type") != "concept"]
+    intv_no_maturity = [
+        n for n in interventions if not present(nodes[n].get("intervention_maturity"))
+    ]
+    concepts_no_category = [
+        n
+        for n, r in nodes.items()
+        if r.get("type") == "concept" and not present(r.get("concept_category"))
+    ]
+    nodes_no_url = [n for n, r in nodes.items() if not present(r.get("url"))]
+
+    # audited vs unaudited share of the release
+    judged_urls = set()
+    for p in sorted(jdir.glob("*.json")):
+        if p.name in ("summary.json", "errors.json"):
+            continue
+        r = json.loads(p.read_text(encoding="utf-8"))
+        if r.get("url"):
+            judged_urls.add(r["url"])
+    nodes_judged = sum(1 for r in nodes.values() if r.get("url") in judged_urls)
+
+    chain_nodes = set()
+    with open(RAW, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                chain_nodes.update(int(x) for x in json.loads(line)["path"])
+
+    out = {
+        "experiment": "released-graph defect inventory and re-gateability (C8/R45/R46/R114)",
+        "substrate": {
+            "nodes": len(nodes),
+            "structural_edges": n_struct,
+            "note": "the un-merged 200,525-node graph this paper reports on",
+        },
+        "does_the_release_ship_the_defect_classes_the_judge_found": {
+            "question": (
+                "The judge reported these classes on 100 papers' extraction JSON. No "
+                "repaired graph was rebuilt, so the released dump should still carry them. "
+                "Measured here on the dump itself, corpus-wide."
+            ),
+            "orphan_nodes_zero_structural_edges": len(orphans),
+            "orphan_pct_of_graph": pct(len(orphans), len(nodes)),
+            "dangling_edges_endpoint_not_in_node_table": dangling,
+            "self_loops": self_loops,
+            "duplicate_edges_same_pair_same_relation_type": dup_edges,
+            "exact_name_duplicate_groups_within_category": len(dup_groups),
+            "exact_name_duplicate_nodes_beyond_one_per_group": dup_nodes_beyond_one,
+            "cross_check": (
+                "app:composition reports 448 groups and 1,140 redundant nodes from "
+                "experiment_J6_merge_approx_v2_report.json; these are re-derived here."
+            ),
+        },
+        "can_a_reuser_re_enumerate_at_any_gate": {
+            "question": "R114 -- is the dump enough, or must a reuser consume our path files?",
+            "structural_edges_missing_a_confidence_value": conf_missing,
+            "structural_edges_missing_a_relation_type": subtype_missing,
+            "intervention_nodes_missing_a_maturity_value": len(intv_no_maturity),
+            "concept_nodes_missing_a_category": len(concepts_no_category),
+            "nodes_missing_a_source_url": len(nodes_no_url),
+            "answer": (
+                "Yes if all five counts above are zero: every attribute the two gates read "
+                "is on the dump, so any gate setting is re-enumerable from it and the path "
+                "files are a convenience, not the only access path."
+            ),
+            "verdict_all_gate_attributes_present": (
+                conf_missing == 0
+                and len(intv_no_maturity) == 0
+                and len(concepts_no_category) == 0
+            ),
+        },
+        "audited_vs_unaudited_content": {
+            "question": "R46 -- can a user tell which part of the release anyone checked?",
+            "judged_source_documents": len(judged_urls),
+            "nodes_from_judged_documents": nodes_judged,
+            "nodes_from_judged_documents_pct": pct(nodes_judged, len(nodes)),
+            "nodes_never_seen_by_any_judge": len(nodes) - nodes_judged,
+            "reading": (
+                "Under one percent of the released nodes were looked at by the judge, and "
+                "no node was looked at by a human. The release should carry a per-node flag "
+                "for this rather than leaving it to the paper's population table."
+            ),
+        },
+        "chain_coverage_of_the_graph": {
+            "nodes_appearing_in_at_least_one_enumerated_chain": len(chain_nodes),
+            "pct_of_graph": pct(len(chain_nodes), len(nodes)),
+            "reading": (
+                "The chain set touches a small share of the released graph. A reuser who "
+                "consumes only the path files is consuming that share."
+            ),
+        },
+        "LIMITS": (
+            "Structural integrity only. An orphan here is a node with no structural edge in "
+            "the dump, which is the judge's own orphan definition applied corpus-wide; it is "
+            "not the same measurement as the judge's per-paper count and the two should not "
+            "be added together."
+        ),
+    }
+
+    OUT.write_text(json.dumps(out, indent=1), encoding="utf-8")
+    print(json.dumps(out, indent=1))
+    print(f"\nwrote {OUT}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/graph_analysis/phase2_results/experiment_review_containment_semantics_report.json
+++ b/graph_analysis/phase2_results/experiment_review_containment_semantics_report.json
@@ -1,0 +1,92 @@
+{
+ "experiment": "semantics of the 70% sub-path collapse (R22/R23)",
+ "question": "The containment rule compares node sets. Reviewers asked what it does to edge identity, order, and to traversals that are arguments in their own right.",
+ "reproduction_check": {
+  "raw_paths": 8954,
+  "kept": 2772,
+  "dropped": 6182,
+  "released_deduped_file": 2772,
+  "keeps_the_same_set_as_the_released_file": true,
+  "note": "The script exits non-zero unless the re-implementation reproduces the released chain set exactly, so every number below describes the substrate the paper reports on."
+ },
+ "node_set_relation": {
+  "node_set_is_subset_of_container": 1342,
+  "partial_overlap_only": 4840,
+  "pct_subset": 21.7,
+  "pct_partial_overlap_only": 78.3,
+  "cross_check_novel_node_share_pct": 78.3,
+  "cross_check_note": "experiment_review_gate_sensitivity_report.json -> containment_losslessness reports 78.3% of dropped paths carrying at least one node their container lacks. That is the same quantity as pct_partial_overlap_only and must agree."
+ },
+ "order_relation": {
+  "non_contiguous_subsequence": 846,
+  "not_a_subsequence_reordered_or_branching": 5336,
+  "pct_contiguous_sub_path": 0.0,
+  "reading": "A contiguous sub-path over the same node order is a restatement by construction: the container traces it and continues. Those drops are unambiguously safe. Everything else is where an annotator would have to decide, and that share is what the paper should state."
+ },
+ "edge_identity": {
+  "traverses_at_least_one_hop_the_container_never_traverses": 6182,
+  "unmatched_hops_are_all_chords_across_container_nodes": 1342,
+  "at_least_one_unmatched_hop_touches_a_node_the_container_lacks": 4840,
+  "pct_with_an_unmatched_hop": 100.0,
+  "pct_chords_only": 21.7,
+  "pct_touching_a_node_the_container_lacks": 78.3,
+  "unmatched_hop_relation_types": {
+   "validated_by": 4354,
+   "motivates": 3683,
+   "implemented_by": 3036,
+   "caused_by": 2595,
+   "mitigated_by": 1289,
+   "enabled_by": 958,
+   "addressed_by": 409,
+   "refined_by": 145,
+   "specified_by": 51,
+   "required_by": 50,
+   "enables": 10,
+   "exacerbated_by": 3,
+   "mitigates": 2
+  },
+  "reading": "This is the reviewers' objection made numeric, and it splits two ways. Every dropped path traverses at least one relation its container does not, so no drop is a strict re-walk. But where the unmatched hops are chords across nodes the container also holds, the two chains trace the same material at different granularity, and calling the drop a repeat is defensible. The other class is a genuine departure."
+ },
+ "does_the_drop_remove_a_distinct_remedy": {
+  "ends_at_an_intervention_the_container_also_contains": 4451,
+  "ends_at_an_intervention_absent_from_the_container": 1731,
+  "pct_ending_at_an_intervention_the_container_lacks": 28.0,
+  "distinct_risk_to_intervention_pairs_raw": 3222,
+  "distinct_risk_to_intervention_pairs_kept": 2643,
+  "distinct_pairs_lost_to_the_collapse": 579,
+  "pct_of_raw_pairs_lost": 18.0,
+  "reading": "This is the sharpest structural form of the reviewers' question. A dropped chain that terminates at an intervention the kept chain never reaches proposes a remedy the reporting unit no longer carries for that risk. The pair counts must agree with experiment_paper_claim_audit.json -> distinct_ri_node_pairs (raw 3,222 / deduped 2,643)."
+ },
+ "shared_prefix_with_container": {
+  "length_histogram_nodes": {
+   "0": 1099,
+   "1": 1424,
+   "2": 271,
+   "3": 683,
+   "4": 1039,
+   "5": 604,
+   "6": 713,
+   "7": 173,
+   "8": 115,
+   "9": 27,
+   "10": 26,
+   "11": 2,
+   "12": 3,
+   "13": 2,
+   "14": 1
+  },
+  "pct_sharing_the_risk_root": 82.2,
+  "reading": "Enumeration is risk-rooted, so a shared prefix is expected; the length at which two chains diverge is where one paper's argument branches."
+ },
+ "novel_node_stage_coverage": {
+  "novel_nodes_are_all_in_stages_the_container_already_has": 4811,
+  "novel_node_introduces_a_stage_the_container_lacks": 29
+ },
+ "parallel_edges_in_the_released_graph": {
+  "node_pairs_carrying_more_than_one_relation_type": 63,
+  "reading": "If this is zero, the collapse cannot conflate two different relations between the same pair of nodes, and the edge-identity question reduces to which node pairs are traversed."
+ },
+ "empty_paths_dropped": 0,
+ "HEADLINE": "Of 6182 dropped paths, 0.0% are contiguous sub-paths of the chain that displaced them; 100.0% traverse at least one relation the kept chain does not, and 28.0% end at an intervention the kept chain never reaches. 579 distinct risk-to-intervention pairs (18.0% of the raw set) are not represented in the reporting unit at all.",
+ "LIMITS": "Structural only. Two traversals over disjoint hops may still be the same argument, and two over identical hops may be read differently. Settling that needs the annotation study of OPEN_ITEMS.md S4."
+}

--- a/graph_analysis/phase2_results/experiment_review_release_integrity_report.json
+++ b/graph_analysis/phase2_results/experiment_review_release_integrity_report.json
@@ -1,0 +1,43 @@
+{
+ "experiment": "released-graph defect inventory and re-gateability (C8/R45/R46/R114)",
+ "substrate": {
+  "nodes": 200525,
+  "structural_edges": 202149,
+  "note": "the un-merged 200,525-node graph this paper reports on"
+ },
+ "does_the_release_ship_the_defect_classes_the_judge_found": {
+  "question": "The judge reported these classes on 100 papers' extraction JSON. No repaired graph was rebuilt, so the released dump should still carry them. Measured here on the dump itself, corpus-wide.",
+  "orphan_nodes_zero_structural_edges": 0,
+  "orphan_pct_of_graph": 0.0,
+  "dangling_edges_endpoint_not_in_node_table": 0,
+  "self_loops": 0,
+  "duplicate_edges_same_pair_same_relation_type": 1,
+  "exact_name_duplicate_groups_within_category": 448,
+  "exact_name_duplicate_nodes_beyond_one_per_group": 1140,
+  "cross_check": "app:composition reports 448 groups and 1,140 redundant nodes from experiment_J6_merge_approx_v2_report.json; these are re-derived here."
+ },
+ "can_a_reuser_re_enumerate_at_any_gate": {
+  "question": "R114 -- is the dump enough, or must a reuser consume our path files?",
+  "structural_edges_missing_a_confidence_value": 0,
+  "structural_edges_missing_a_relation_type": 0,
+  "intervention_nodes_missing_a_maturity_value": 0,
+  "concept_nodes_missing_a_category": 0,
+  "nodes_missing_a_source_url": 0,
+  "answer": "Yes if all five counts above are zero: every attribute the two gates read is on the dump, so any gate setting is re-enumerable from it and the path files are a convenience, not the only access path.",
+  "verdict_all_gate_attributes_present": true
+ },
+ "audited_vs_unaudited_content": {
+  "question": "R46 -- can a user tell which part of the release anyone checked?",
+  "judged_source_documents": 100,
+  "nodes_from_judged_documents": 1617,
+  "nodes_from_judged_documents_pct": 0.81,
+  "nodes_never_seen_by_any_judge": 198908,
+  "reading": "Under one percent of the released nodes were looked at by the judge, and no node was looked at by a human. The release should carry a per-node flag for this rather than leaving it to the paper's population table."
+ },
+ "chain_coverage_of_the_graph": {
+  "nodes_appearing_in_at_least_one_enumerated_chain": 19073,
+  "pct_of_graph": 9.51,
+  "reading": "The chain set touches a small share of the released graph. A reuser who consumes only the path files is consuming that share."
+ },
+ "LIMITS": "Structural integrity only. An orphan here is a node with no structural edge in the dump, which is the judge's own orphan definition applied corpus-wide; it is not the same measurement as the judge's per-paper count and the two should not be added together."
+}


### PR DESCRIPTION
Closes #157. Two Class B scripts, zero dollars, no LLM call. Both refuse to report if the substrate does not reproduce.

## A. `experiment_review_containment_semantics.py`

Re-implements the sub-path collapse as `phase1_dedup_paths.py` ran it and **exits non-zero unless it reproduces the released 2,772-of-8,954 chain set member-for-member**, then characterises every one of the 6,182 drops against the chain that displaced it.

| measure | result |
|---|---|
| contiguous sub-path of its container | **0 (0.0%)** |
| traverses a relation the container never traverses | 6,182 (100%) |
| ... unmatched hops are chords across nodes the container also holds | 1,342 (21.7%) |
| ... at least one touches a node the container lacks | 4,840 (78.3%) |
| **ends at an intervention the container never reaches** | **1,731 (28.0%)** |
| **distinct risk-to-intervention pairs lost** | **579 of 3,222 (18.0%)** |

The first row is the finding. The Methods sentence describing the step as removing "sub-paths already counted inside a longer path from the same document" does not describe what the rule does -- **not one** drop is a strict re-walk. The 21.7% chord class is where calling a drop a repeat is defensible: the two chains trace the same material at different granularity, the dropped one taking a direct relation across a node the container walks through. The remaining 78.3% is a departure, and for 28% of all drops the dropped chain proposes a remedy the reporting unit no longer carries for that risk.

The paper's existing evidence for the step ("the structure is almost unchanged, 89.0% -> 87.4% all-five over an identical set of source papers") is untouched by this and still holds. What changes is the framing of *why* the drops are safe.

Cross-checks that must and do agree: 78.3% novel-node share (`experiment_review_gate_sensitivity_report.json` -> `containment_losslessness`), 3,222 / 2,643 distinct R-I pairs (`experiment_paper_claim_audit.json`).

**Method note worth keeping.** Hop-wise enumeration walks structural edges without regard to direction -- 94.1% of the hops in the released path file match an edge `source -> target`, 100% match one unordered. A first pass keyed pairs directed and reported 2,193 hops as "absent from the released EDGE set", which was an artifact of the keying, not a finding. Pairs are keyed unordered and the reason is in the source.

## B. `experiment_review_release_integrity.py`

| check | result |
|---|---|
| orphan nodes / dangling edges / self-loops | **0 / 0 / 0** |
| duplicate edges (same pair, same relation type) | 1 |
| exact-name duplicate groups within category | 448 (1,140 nodes beyond one per group) |
| structural edges missing confidence / relation type | **0 / 0** |
| intervention nodes missing maturity | **0** |
| concept nodes missing category / nodes missing source URL | **0 / 0** |
| nodes from a judged document | 1,617 of 200,525 (**0.81%**) |
| nodes in at least one enumerated chain | 19,073 (9.51%) |

Answers to the three questions that prompted it: the released dump does **not** carry the judge's structural defect classes -- those were properties of the pre-ingest extraction JSON and ingestion resolved them, which the paper should say rather than leaving a reader to assume the 108/42/56 findings ship. The surviving defect is the near-duplicate residue, re-derived here from the node table instead of quoted from the merge experiment. A reuser **can** re-enumerate at any gate setting from the dump alone. And under one percent of released nodes were seen by any judge, which argues for a per-node audited flag in the release.

Reproduce:

```bash
cd graph_analysis
python -u experiment_review_containment_semantics.py
git archive origin/anthropic_judge_test extraction_validator/extend_try_1 | tar -x -C /tmp/judge
python -u experiment_review_release_integrity.py --judge-reports /tmp/judge/extraction_validator/extend_try_1
```

Manuscript changes land separately in `AISafetyIntervention_PaperA_shared`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)