### PR TITLE
Claim audit re-pointed at the current manuscript (218 -> 235), docs marked down

### DIFF
--- a/graph_analysis/experiment_paper_claim_audit.py
+++ b/graph_analysis/experiment_paper_claim_audit.py
@@ -345,40 +345,26 @@ def main():
         loss["n_papers_with_at_least_one_lost_node"],
     )
 
-    ga = receipt("experiment_review_grader_agreement_report.json")[
-        "raw_score_agreement"
-    ]
-    check("grader ICC(2,1) pre-repair", 0.921, ga["pre_repair"]["ICC_2_1"])
-    check("grader ICC(2,1) post-repair", 0.151, ga["post_repair"]["ICC_2_1"])
-    check("grader ICC(2,k) pre-repair", 0.972, ga["pre_repair"]["ICC_2_k"])
-    check("grader ICC(2,k) post-repair", 0.348, ga["post_repair"]["ICC_2_k"])
-    check(
-        "grader Krippendorff alpha pre-repair",
-        0.917,
-        ga["pre_repair"]["krippendorff_alpha_interval"],
-    )
-    check(
-        "grader Krippendorff alpha post-repair",
-        0.043,
-        ga["post_repair"]["krippendorff_alpha_interval"],
-    )
-
-    # ---- grader session diagnostics (tab:graders caption, sec:m-repro) --------------
+    # REMOVED 2026-08-16: six checks on the grader agreement instruments (ICC(2,1),
+    # ICC(2,k), Krippendorff alpha, pre and post) and the per-grader files-seen and
+    # JSON-shape diagnostics. None of those numbers is printed in the manuscript any more
+    # -- the pre/post repair-scoring stage was compressed to a design lesson with no
+    # statistics, unanimously across six external reviews. The receipts still ship and
+    # experiment_review_grader_agreement.py still produces them; if the null-repair arm is
+    # ever run and the stage becomes a result, restore these checks with it.
+    # A check for a number the paper does not print is not a regression test.
     mg = receipt("experiment_judge_full_report.json")["item2_meta_graders"]
-    for key, n, files, shapes in [
-        ("claude-opus-4-5", 95, 101, 13),
-        ("gemini-3-pro", 13, 100, 12),
-        ("third_grader_gpt-5.1", 95, 95, 1),
+    for key, n in [
+        ("claude-opus-4-5", 95),
+        ("gemini-3-pro", 13),
+        ("third_grader_gpt-5.1", 95),
     ]:
-        cd = mg[key]["coverage_diagnostics"]
-        check(f"grader {key}: paired pre/post rows", n, mg[key]["n"])
-        check(f"grader {key}: files seen", files, cd["files_seen"])
         check(
-            f"grader {key}: distinct JSON shapes",
-            shapes,
-            cd["n_distinct_json_shapes"],
-            note="the agent-session design of app:judgeprompt is why the shape drifts "
-            "within one grader's output; 1 shape -> a paired score on every file",
+            f"grader {key}: paired pre/post rows",
+            n,
+            mg[key]["n"],
+            note="printed in tab:populations-master as the 95/95/13 row; the per-grader "
+            "session diagnostics behind those denominators left the paper 2026-08-16",
         )
 
     om = receipt("experiment_review_omission_relative_report.json")
@@ -390,15 +376,170 @@ def main():
         0.6,
         j["omissions_as_pct_of_extracted_nodes"],
     )
-    check("judge implied coverage pct", 99.4, j["implied_coverage_pct"])
     check("profiled papers: extracted nodes", 751, g["extracted_nodes_total"])
     check(
         "missed concepts as pct of extracted nodes",
         28.8,
         g["omissions_as_pct_of_extracted_nodes"],
     )
-    check("grader implied coverage pct", 77.7, g["implied_coverage_pct"])
     check("missed concepts total", 216, g["omissions_total"])
+    # REMOVED 2026-08-16: the two "implied coverage" checks (99.4% and 77.7%). The phrase
+    # is gone from the paper -- reviewers read it as an accuracy claim when it is one minus
+    # an unadjudicated flag rate, and the edge measurement below made the node-only version
+    # of it misleading as a headline.
+
+    # ---- edge-level coverage (S10, issue #156) --------------------------------------
+    ec = receipt("experiment_review_edge_coverage_report.json")
+    cl = ec["coverage_list"]
+    against = ec["against_the_extraction_it_is_measured_on"]
+    check("coverage list: rows over the 100 judged papers", 777, cl["rows_total"])
+    check("coverage list: covered", 328, cl["covered"])
+    check("coverage list: partially covered", 146, cl["partially_covered"])
+    check("coverage list: missing", 302, cl["missing"])
+    check("coverage list: missing per paper", 3.02, cl["missing_mean_per_paper"])
+    check(
+        "coverage list: papers with at least one missing",
+        90,
+        cl["papers_with_at_least_one_missing"],
+    )
+    check(
+        "judged papers: structural edges in the released graph",
+        1667,
+        against["released_edges_total"],
+    )
+    check(
+        "judged papers: released edges per paper",
+        16.7,
+        against["released_edges_mean_per_paper"],
+        note="app:judge prints this beside the judge's own final_graph mean of 10.8",
+    )
+    check(
+        "missing relationships as pct of extracted edges",
+        18.1,
+        against["missing_as_pct_of_released_edges"],
+        note="the abstract's third omission rate",
+    )
+    check(
+        "same count against the judge's own edge total",
+        28.1,
+        ec["which_denominator"]["missing_as_pct_of_judge_final_graph_edges"],
+    )
+    check(
+        "judge final_graph edges per paper",
+        10.76,
+        ec["which_denominator"]["judge_final_graph_edges_mean_per_paper"],
+    )
+    check(
+        "judge repair schema has no add_edges slot",
+        False,
+        ec["no_add_edges_slot"]["has_add_edges_key"],
+        note="app:judgeprompt and sec:r-judge give this absence as the explanation for the "
+        "gap between the node-addition count and the coverage list",
+    )
+    check(
+        "structural edges crossing two source papers",
+        0,
+        ec["released_graph_structural_edges"]["n_crossing_two_source_papers"],
+        note="single-source-by-design, sec:m-structural",
+    )
+
+    # ---- what the sub-path collapse drops (issue #157) -------------------------------
+    cs = receipt("experiment_review_containment_semantics_report.json")
+    check(
+        "collapse: dropped paths that are contiguous sub-paths of their container",
+        0.0,
+        cs["order_relation"]["pct_contiguous_sub_path"],
+        note="sec:m-reporting no longer describes the step as dropping sub-paths already "
+        "counted inside a longer path; this is why",
+    )
+    check(
+        "collapse: drops differing only by chords",
+        21.7,
+        cs["edge_identity"]["pct_chords_only"],
+    )
+    check(
+        "collapse: drops touching a node the container lacks",
+        78.3,
+        cs["edge_identity"]["pct_touching_a_node_the_container_lacks"],
+    )
+    check(
+        "collapse: drops ending at an intervention the container lacks",
+        28.0,
+        cs["does_the_drop_remove_a_distinct_remedy"][
+            "pct_ending_at_an_intervention_the_container_lacks"
+        ],
+    )
+    check(
+        "collapse: distinct risk-to-intervention pairs lost",
+        579,
+        cs["does_the_drop_remove_a_distinct_remedy"][
+            "distinct_pairs_lost_to_the_collapse"
+        ],
+    )
+    check(
+        "collapse: pct of raw R-I pairs lost",
+        18.0,
+        cs["does_the_drop_remove_a_distinct_remedy"]["pct_of_raw_pairs_lost"],
+    )
+
+    # ---- what the release ships (issue #157) -----------------------------------------
+    ri = receipt("experiment_review_release_integrity_report.json")
+    defects = ri["does_the_release_ship_the_defect_classes_the_judge_found"]
+    for label, expected, key in [
+        ("orphan nodes", 0, "orphan_nodes_zero_structural_edges"),
+        ("dangling edges", 0, "dangling_edges_endpoint_not_in_node_table"),
+        ("self-loops", 0, "self_loops"),
+        ("duplicate edges", 1, "duplicate_edges_same_pair_same_relation_type"),
+        (
+            "exact-name duplicate groups",
+            448,
+            "exact_name_duplicate_groups_within_category",
+        ),
+        (
+            "exact-name duplicate nodes beyond one per group",
+            1140,
+            "exact_name_duplicate_nodes_beyond_one_per_group",
+        ),
+    ]:
+        check(f"released graph: {label}", expected, defects[key])
+    check(
+        "every gate attribute present on the released graph",
+        True,
+        ri["can_a_reuser_re_enumerate_at_any_gate"][
+            "verdict_all_gate_attributes_present"
+        ],
+        note="sec:m-repro claims a reuser can re-enumerate at any gate setting from the "
+        "dump alone, which is only true while this holds",
+    )
+    check(
+        "released nodes from a judged document",
+        1617,
+        ri["audited_vs_unaudited_content"]["nodes_from_judged_documents"],
+    )
+    check(
+        "released nodes from a judged document, pct",
+        0.81,
+        ri["audited_vs_unaudited_content"]["nodes_from_judged_documents_pct"],
+    )
+
+    # ---- extraction-failure recovery, now printed in the body (C6) -------------------
+    rec = receipt("experiment_judge_full_report.json")["item3_recovery"][
+        "population_A_extraction_error_candidates"
+    ]
+    check("recovery: judgeable failed extractions", 441, rec["n_judgeable_candidates"])
+    check(
+        "recovery: attempts producing a non-empty graph",
+        23,
+        rec["n_attempts_producing_nonempty_graph"],
+    )
+    check(
+        "recovery rate pct",
+        5.2,
+        rec["recovery_rate_pct"],
+        note="sec:m-recovery prints this from 2026-08-16; it used to say 'not at a useful "
+        "rate' with no number. The '~60 of ~400' in older project notes divides two "
+        "disjoint populations and is wrong",
+    )
 
     sil = receipt("experiment_review_silhouette_report.json")["headline"]
     check(

--- a/graph_analysis/experiment_review_containment_semantics.py
+++ b/graph_analysis/experiment_review_containment_semantics.py
@@ -1,0 +1,398 @@
+#!/usr/bin/env python
+"""What exactly does the 70% sub-path collapse drop, in terms a reader can check?
+
+Reviewers of the 2026-08-15 round raised the same objection twice: the containment rule
+compares NODE SETS, so it is blind to edge identity, to order, and to whether the dropped
+traversal is an argument the kept one does not carry. The paper answers with two numbers
+(78.3% of dropped paths carry a novel node; 6.1% of chain-set nodes survive in no kept
+chain) and concedes the step is not lossless. Neither number says whether a dropped path
+was already traced by its container.
+
+This script re-implements the collapse exactly as phase1_dedup_paths.py ran it -- greedy,
+longest-first, threshold 0.70, within source paper -- asserts it reproduces the released
+2,772/8,954 split before reporting anything, then records for every dropped path WHICH kept
+path displaced it and how the two relate:
+
+  * node-set relation      -- is the dropped path's node set a subset of its container's?
+  * order                  -- is the dropped node sequence a contiguous sub-path of the
+                              container, a non-contiguous subsequence, or neither?
+  * edge identity          -- is every consecutive pair the dropped path traverses also
+                              consecutive in the container? If not, the dropped path walks
+                              a relation the container never walks, which is precisely what
+                              a node-set rule cannot see.
+  * relation semantics     -- the edge subtypes on those unmatched hops, and whether the
+                              released graph carries parallel edges (same node pair, two
+                              relation types) at all.
+  * stage coverage         -- do the dropped path's novel nodes introduce a logical-chain
+                              stage the container lacks?
+
+Class B (no LLM call, no network). Run from graph_analysis/:
+
+    python -u experiment_review_containment_semantics.py
+
+Output: graph_analysis/phase2_results/experiment_review_containment_semantics_report.json
+
+What this cannot do: decide whether two traversals are the same ARGUMENT. That is an
+annotation question (OPEN_ITEMS.md S4/R23). It bounds the question from below -- a dropped
+path that is a contiguous sub-path of its container, over the same edges, is a restatement
+by construction, and the rest are where an annotator would have to look.
+"""
+
+import json
+import pickle
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+ROOT = Path(__file__).parent
+SLIM = ROOT / "phase2_results/node_attrs_slim.pkl"
+EDGES = (
+    ROOT
+    / "phase2_results/step1_load_and_parse_umapwithoutlocalsatellites/graph_edge_data.pkl"
+)
+RAW = ROOT / "phase1_rawpathsfiles/paths_hopwise_v4_edge_only.jsonl"
+DEDUPED = ROOT / "phase1_rawpathsfiles/paths_hopwise_v4_edge_only_deduped.jsonl"
+OUT = ROOT / "phase2_results/experiment_review_containment_semantics_report.json"
+
+CONTAINMENT_THRESHOLD = (
+    0.70  # phase1_dedup_paths.py: the code uses 0.70, docstring says 80%
+)
+EXPECTED_RAW, EXPECTED_KEPT = 8954, 2772
+
+STAGES = (
+    "risk",
+    "problem analysis",
+    "theoretical insight",
+    "design rationale",
+    "implementation mechanism",
+    "validation evidence",
+)
+
+
+def pct(n, d, nd=1):
+    return round(100 * n / d, nd) if d else None
+
+
+def load_paths(fp):
+    out = []
+    with open(fp, encoding="utf-8") as f:
+        for i, line in enumerate(f, 1):
+            line = line.strip()
+            if not line:
+                continue
+            d = json.loads(line)
+            d["path_id"] = f"path_{i:05d}"
+            out.append(d)
+    return out
+
+
+def is_contiguous_subpath(small, large):
+    n = len(small)
+    return any(large[i : i + n] == small for i in range(len(large) - n + 1))
+
+
+def is_subsequence(small, large):
+    it = iter(large)
+    return all(any(x == y for y in it) for x in small)
+
+
+def main():
+    for p, how in (
+        (SLIM, "run experiment_review_prep_slim_nodes.py"),
+        (EDGES, "run phase2_step1_loadandparse.py against the FalkorDB dump"),
+        (RAW, "the released 8,954-chain path file ships with the repo"),
+        (DEDUPED, "the released 2,772-chain path file ships with the repo"),
+    ):
+        if not p.exists():
+            raise SystemExit(f"FATAL: {p} not found. To produce it: {how}.")
+
+    slim = pickle.load(open(SLIM, "rb"))
+    url_of = {int(n): r.get("url") for n, r in slim.items()}
+    cat_of = {
+        int(n): (
+            r.get("concept_category") if r.get("type") == "concept" else "intervention"
+        )
+        for n, r in slim.items()
+    }
+
+    edges = pickle.load(open(EDGES, "rb"))
+    # Hop-wise enumeration walks structural edges without regard to direction: 94.1% of the
+    # hops in the released path file match an edge (source -> target) and 100% match one
+    # (source, target) unordered, so pairs are keyed unordered here. Keying them directed
+    # would report every reversed hop as an edge the graph does not contain.
+    subtypes_of_pair = defaultdict(set)
+    for e in edges:
+        if e.get("type") != "EDGE":
+            continue
+        subtypes_of_pair[frozenset((e["source"], e["target"]))].add(e.get("subtype"))
+    parallel_pairs = sum(1 for v in subtypes_of_pair.values() if len(v) > 1)
+
+    raw = load_paths(RAW)
+    deduped = load_paths(DEDUPED)
+    if len(raw) != EXPECTED_RAW:
+        raise SystemExit(
+            f"FATAL: raw path file has {len(raw)}, expected {EXPECTED_RAW}"
+        )
+
+    # ---- re-implement the collapse, recording the container of every drop ---------------
+    by_url = defaultdict(list)
+    for p in raw:
+        urls = {url_of.get(int(n)) for n in p["path"]}
+        urls.discard(None)
+        if len(urls) == 1:
+            by_url[next(iter(urls))].append(p)
+        elif not urls:
+            by_url[f"_orphan_{p['path_id']}"].append(p)
+        else:
+            by_url[f"_mixed_{p['path_id']}"].append(p)
+
+    keep, drops = set(), []
+    for _url, plist in by_url.items():
+        ordered = sorted(plist, key=lambda p: -len(p["path"]))
+        sets = [(p["path_id"], frozenset(p["path"])) for p in ordered]
+        for i, (pid_i, ns_i) in enumerate(sets):
+            if not ns_i:
+                drops.append((pid_i, None))
+                continue
+            container = None
+            for pid_j, ns_j in sets[:i]:
+                if pid_j not in keep or not ns_j:
+                    continue
+                small, large = (ns_i, ns_j) if len(ns_i) <= len(ns_j) else (ns_j, ns_i)
+                if len(small & large) / len(small) >= CONTAINMENT_THRESHOLD:
+                    container = pid_j
+                    break
+            if container is None:
+                keep.add(pid_i)
+            else:
+                drops.append((pid_i, container))
+
+    if len(keep) != EXPECTED_KEPT:
+        raise SystemExit(
+            f"FATAL: re-implementation kept {len(keep)}, released file has {EXPECTED_KEPT}. "
+            "The procedure below does not reproduce the released substrate; nothing here "
+            "is reportable until it does."
+        )
+    released_ids = {tuple(p["path"]) for p in deduped}
+    kept_ids = {tuple(p["path"]) for p in raw if p["path_id"] in keep}
+    if released_ids != kept_ids:
+        raise SystemExit(
+            "FATAL: re-implementation keeps a different SET of chains than the released "
+            f"file ({len(released_ids ^ kept_ids)} symmetric-difference members)."
+        )
+
+    path_of = {p["path_id"]: p["path"] for p in raw}
+
+    # ---- characterise every drop --------------------------------------------------------
+    rel = Counter()
+    order = Counter()
+    edge_id = Counter()
+    endpoint = Counter()
+    unmatched_hop_subtypes = Counter()
+    novel_stage = Counter()
+    shared_prefix_len = Counter()
+    n_novel_node = 0
+    empty_drops = 0
+
+    for pid, cid in drops:
+        if cid is None:
+            empty_drops += 1
+            continue
+        d, c = path_of[pid], path_of[cid]
+        ds, cs = set(d), set(c)
+
+        # Does the dropped chain propose an intervention the kept chain never reaches?
+        # This is the reviewers' question in the form the data can answer: a chain ending
+        # at a different remedy is a different risk-to-intervention claim, whatever the
+        # node-set overlap.
+        endpoint[
+            "ends_at_an_intervention_absent_from_the_container"
+            if d[-1] not in cs
+            else "ends_at_an_intervention_the_container_also_contains"
+        ] += 1
+
+        k = 0
+        for x, y in zip(d, c):
+            if x != y:
+                break
+            k += 1
+        shared_prefix_len[k] += 1
+
+        subset = ds <= cs
+        rel[
+            "node_set_is_subset_of_container" if subset else "partial_overlap_only"
+        ] += 1
+        if not subset:
+            n_novel_node += 1
+            novel = ds - cs
+            cont_stages = {cat_of.get(int(n)) for n in c}
+            if any(cat_of.get(int(n)) not in cont_stages for n in novel):
+                novel_stage["novel_node_introduces_a_stage_the_container_lacks"] += 1
+            else:
+                novel_stage[
+                    "novel_nodes_are_all_in_stages_the_container_already_has"
+                ] += 1
+
+        if is_contiguous_subpath(d, c):
+            order["contiguous_sub_path_of_container"] += 1
+        elif is_subsequence(d, c):
+            order["non_contiguous_subsequence"] += 1
+        else:
+            order["not_a_subsequence_reordered_or_branching"] += 1
+
+        chops = {frozenset(h) for h in zip(c, c[1:])}
+        dhops = [frozenset(h) for h in zip(d, d[1:])]
+        unmatched = [h for h in dhops if h not in chops]
+        if unmatched:
+            edge_id["traverses_at_least_one_hop_the_container_never_traverses"] += 1
+            # Not every unmatched hop is equal. A hop whose two endpoints both sit in the
+            # container is a chord -- the dropped path takes a direct relation across a node
+            # the container walks through, so the two trace the same material at different
+            # granularity. A hop touching a node the container lacks is a genuine departure.
+            if all(h <= cs for h in unmatched):
+                edge_id["unmatched_hops_are_all_chords_across_container_nodes"] += 1
+            else:
+                edge_id[
+                    "at_least_one_unmatched_hop_touches_a_node_the_container_lacks"
+                ] += 1
+            for h in unmatched:
+                for s in subtypes_of_pair.get(h, {"<absent from released EDGE set>"}):
+                    unmatched_hop_subtypes[s] += 1
+        else:
+            edge_id["every_hop_is_also_a_hop_of_the_container"] += 1
+
+    n_drops = len(drops)
+    strict = order["contiguous_sub_path_of_container"]
+
+    ri_raw = {(p["path"][0], p["path"][-1]) for p in raw}
+    ri_kept = {(p["path"][0], p["path"][-1]) for p in deduped}
+    lost_pairs = ri_raw - ri_kept
+
+    out = {
+        "experiment": "semantics of the 70% sub-path collapse (R22/R23)",
+        "question": (
+            "The containment rule compares node sets. Reviewers asked what it does to edge "
+            "identity, order, and to traversals that are arguments in their own right."
+        ),
+        "reproduction_check": {
+            "raw_paths": len(raw),
+            "kept": len(keep),
+            "dropped": n_drops,
+            "released_deduped_file": len(deduped),
+            "keeps_the_same_set_as_the_released_file": True,
+            "note": (
+                "The script exits non-zero unless the re-implementation reproduces the "
+                "released chain set exactly, so every number below describes the substrate "
+                "the paper reports on."
+            ),
+        },
+        "node_set_relation": {
+            **dict(rel),
+            "pct_subset": pct(rel["node_set_is_subset_of_container"], n_drops),
+            "pct_partial_overlap_only": pct(rel["partial_overlap_only"], n_drops),
+            "cross_check_novel_node_share_pct": pct(n_novel_node, n_drops),
+            "cross_check_note": (
+                "experiment_review_gate_sensitivity_report.json -> "
+                "containment_losslessness reports 78.3% of dropped paths carrying at least "
+                "one node their container lacks. That is the same quantity as "
+                "pct_partial_overlap_only and must agree."
+            ),
+        },
+        "order_relation": {
+            **dict(order),
+            "pct_contiguous_sub_path": pct(strict, n_drops),
+            "reading": (
+                "A contiguous sub-path over the same node order is a restatement by "
+                "construction: the container traces it and continues. Those drops are "
+                "unambiguously safe. Everything else is where an annotator would have to "
+                "decide, and that share is what the paper should state."
+            ),
+        },
+        "edge_identity": {
+            **dict(edge_id),
+            "pct_with_an_unmatched_hop": pct(
+                edge_id["traverses_at_least_one_hop_the_container_never_traverses"],
+                n_drops,
+            ),
+            "pct_chords_only": pct(
+                edge_id["unmatched_hops_are_all_chords_across_container_nodes"], n_drops
+            ),
+            "pct_touching_a_node_the_container_lacks": pct(
+                edge_id[
+                    "at_least_one_unmatched_hop_touches_a_node_the_container_lacks"
+                ],
+                n_drops,
+            ),
+            "unmatched_hop_relation_types": dict(unmatched_hop_subtypes.most_common()),
+            "reading": (
+                "This is the reviewers' objection made numeric, and it splits two ways. "
+                "Every dropped path traverses at least one relation its container does not, "
+                "so no drop is a strict re-walk. But where the unmatched hops are chords "
+                "across nodes the container also holds, the two chains trace the same "
+                "material at different granularity, and calling the drop a repeat is "
+                "defensible. The other class is a genuine departure."
+            ),
+        },
+        "does_the_drop_remove_a_distinct_remedy": {
+            **dict(endpoint),
+            "pct_ending_at_an_intervention_the_container_lacks": pct(
+                endpoint["ends_at_an_intervention_absent_from_the_container"], n_drops
+            ),
+            "distinct_risk_to_intervention_pairs_raw": len(ri_raw),
+            "distinct_risk_to_intervention_pairs_kept": len(ri_kept),
+            "distinct_pairs_lost_to_the_collapse": len(lost_pairs),
+            "pct_of_raw_pairs_lost": pct(len(lost_pairs), len(ri_raw)),
+            "reading": (
+                "This is the sharpest structural form of the reviewers' question. A dropped "
+                "chain that terminates at an intervention the kept chain never reaches "
+                "proposes a remedy the reporting unit no longer carries for that risk. The "
+                "pair counts must agree with experiment_paper_claim_audit.json -> "
+                "distinct_ri_node_pairs (raw 3,222 / deduped 2,643)."
+            ),
+        },
+        "shared_prefix_with_container": {
+            "length_histogram_nodes": {
+                str(k): v for k, v in sorted(shared_prefix_len.items())
+            },
+            "pct_sharing_the_risk_root": pct(
+                sum(v for k, v in shared_prefix_len.items() if k >= 1), n_drops
+            ),
+            "reading": (
+                "Enumeration is risk-rooted, so a shared prefix is expected; the length at "
+                "which two chains diverge is where one paper's argument branches."
+            ),
+        },
+        "novel_node_stage_coverage": dict(novel_stage),
+        "parallel_edges_in_the_released_graph": {
+            "node_pairs_carrying_more_than_one_relation_type": parallel_pairs,
+            "reading": (
+                "If this is zero, the collapse cannot conflate two different relations "
+                "between the same pair of nodes, and the edge-identity question reduces to "
+                "which node pairs are traversed."
+            ),
+        },
+        "empty_paths_dropped": empty_drops,
+        "HEADLINE": (
+            f"Of {n_drops} dropped paths, {pct(strict, n_drops)}% are contiguous sub-paths of "
+            f"the chain that displaced them; "
+            f"{pct(edge_id['traverses_at_least_one_hop_the_container_never_traverses'], n_drops)}% "
+            "traverse at least one relation the kept chain does not, and "
+            f"{pct(endpoint['ends_at_an_intervention_absent_from_the_container'], n_drops)}% "
+            f"end at an intervention the kept chain never reaches. {len(lost_pairs)} distinct "
+            f"risk-to-intervention pairs ({pct(len(lost_pairs), len(ri_raw))}% of the raw set) "
+            "are not represented in the reporting unit at all."
+        ),
+        "LIMITS": (
+            "Structural only. Two traversals over disjoint hops may still be the same "
+            "argument, and two over identical hops may be read differently. Settling that "
+            "needs the annotation study of OPEN_ITEMS.md S4."
+        ),
+    }
+
+    OUT.write_text(json.dumps(out, indent=1), encoding="utf-8")
+    print(json.dumps(out, indent=1))
+    print(f"\nwrote {OUT}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/graph_analysis/experiment_review_edge_coverage.py
+++ b/graph_analysis/experiment_review_edge_coverage.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python
+"""Break the judge's coverage list out by status, against the edges the extraction produced.
+
+The paper reports node-level omission twice (0.6% and 28.8%, tab:omission) and reports the
+judge's *edge* coverage list only as a per-paper mean of 7.8 "missing relationships",
+buried in two appendices. A reviewer set that 7.8 against the mean audited extraction of
+10.8 edges and concluded edge recall may be poor while node recall looks high.
+
+That comparison does not hold, and this script is what shows it. The 7.8 is
+`len(validation_report.coverage.expected_edges_from_source)` -- the length of the WHOLE
+coverage list, computed that way in experiment_judge_item2_summary.py:144. Every row of
+that list carries a `status` field taking one of covered / partially_covered / missing, so
+the list is the judge's inventory of relationships it went looking for, not its count of
+ones the extraction lacks. This script reads the status field and reports the three classes
+separately, then puts the genuinely-missing count on the same denominator tab:omission uses
+for nodes: the edges the RELEASED graph holds for the same papers.
+
+Class B (no LLM call, no network). Run from graph_analysis/:
+
+    python -u experiment_review_edge_coverage.py --judge-reports <dir>
+
+where <dir> is extraction_validator/extend_try_1 from branch anthropic_judge_test:
+
+    git archive origin/anthropic_judge_test extraction_validator/extend_try_1 | tar -x -C /tmp/judge
+
+Output: graph_analysis/phase2_results/experiment_review_edge_coverage_report.json
+
+This script does NOT adjudicate any judge verdict. A row labelled `missing` is the judge's
+opinion, unchecked by a human, exactly like every other number in sec:r-judge.
+"""
+
+import argparse
+import json
+import pickle
+import statistics as st
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+ROOT = Path(__file__).parent
+SLIM = ROOT / "phase2_results/node_attrs_slim.pkl"
+EDGES = (
+    ROOT
+    / "phase2_results/step1_load_and_parse_umapwithoutlocalsatellites/graph_edge_data.pkl"
+)
+OUT = ROOT / "phase2_results/experiment_review_edge_coverage_report.json"
+
+# The judged sample's file names carry the ARD source type as a prefix, which is how
+# experiment_judge_item2_summary.py buckets them. Reused here so the two receipts agree.
+SKIP_FILES = {"summary.json", "errors.json"}
+
+
+def pct(n, d, nd=1):
+    return round(100 * n / d, nd) if d else None
+
+
+def source_type(fname):
+    return fname.split("__")[0] if "__" in fname else "unknown"
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--judge-reports", required=True)
+    a = ap.parse_args()
+
+    jdir = Path(a.judge_reports)
+    if not jdir.is_dir():
+        raise SystemExit(
+            f"FATAL: judge report directory not found: {jdir}\n"
+            "  produce it with:\n"
+            "    git archive origin/anthropic_judge_test extraction_validator/extend_try_1"
+            " | tar -x -C /tmp/judge\n"
+            "  this script does NOT fall back to a cached or partial copy."
+        )
+    for p, how in (
+        (SLIM, "run experiment_review_prep_slim_nodes.py"),
+        (EDGES, "run phase2_step1_loadandparse.py against the FalkorDB dump"),
+    ):
+        if not p.exists():
+            raise SystemExit(f"FATAL: {p} not found. To produce it: {how}.")
+
+    # ---- released graph: EDGE-type edges per source paper -------------------------------
+    slim = pickle.load(open(SLIM, "rb"))
+    url_of_node = {nid: r.get("url") for nid, r in slim.items() if r.get("url")}
+    edges = pickle.load(open(EDGES, "rb"))
+
+    edges_per_url = Counter()
+    cross_paper_edges = 0
+    n_structural = 0
+    for e in edges:
+        if e.get("type") != "EDGE":
+            continue
+        n_structural += 1
+        su, tu = url_of_node.get(e["source"]), url_of_node.get(e["target"])
+        if su and tu and su != tu:
+            cross_paper_edges += 1
+        if su:
+            edges_per_url[su] += 1
+
+    # ---- judge reports: the coverage list, by status ------------------------------------
+    rows = []
+    status_counter = Counter()
+    proposed_fix_keys = Counter()
+    unmatched = []
+    for p in sorted(jdir.glob("*.json")):
+        if p.name in SKIP_FILES:
+            continue
+        r = json.loads(p.read_text(encoding="utf-8"))
+        cov = ((r.get("validation_report") or {}).get("coverage") or {}).get(
+            "expected_edges_from_source"
+        ) or []
+        by_status = Counter()
+        for row in cov:
+            s = (row.get("status") or "unlabelled").strip().lower()
+            by_status[s] += 1
+            status_counter[s] += 1
+        for k in r.get("proposed_fixes") or {}:
+            proposed_fix_keys[k] += 1
+        fg = r.get("final_graph") or {}
+        url = r.get("url")
+        n_edges = edges_per_url.get(url) if url else None
+        if not n_edges:
+            unmatched.append(p.name)
+        rows.append(
+            {
+                "paper": p.name,
+                "source_type": source_type(p.name),
+                "url": url,
+                "coverage_rows": len(cov),
+                "covered": by_status.get("covered", 0),
+                "partially_covered": by_status.get("partially_covered", 0),
+                "missing": by_status.get("missing", 0),
+                "other_status": len(cov)
+                - by_status.get("covered", 0)
+                - by_status.get("partially_covered", 0)
+                - by_status.get("missing", 0),
+                "released_edges": n_edges,
+                "judge_final_graph_edges": len(fg.get("edges") or []),
+                "judge_final_graph_nodes": len(fg.get("nodes") or []),
+            }
+        )
+
+    if not rows:
+        raise SystemExit(f"FATAL: no judge reports parsed from {jdir}")
+
+    n_papers = len(rows)
+    matched = [r for r in rows if r["released_edges"]]
+    tot = {
+        k: sum(r[k] for r in rows)
+        for k in (
+            "coverage_rows",
+            "covered",
+            "partially_covered",
+            "missing",
+            "other_status",
+        )
+    }
+    tot_edges_matched = sum(r["released_edges"] for r in matched)
+    missing_matched = sum(r["missing"] for r in matched)
+    partial_matched = sum(r["partially_covered"] for r in matched)
+
+    out = {
+        "experiment": "judge edge-coverage list, broken out by status (S10)",
+        "question": (
+            "The paper quotes a mean of 7.8 flagged relationships per paper against a mean "
+            "audited extraction of 10.8 edges, which reads as an edge-omission signal of "
+            "the same order as the extraction. Is it one?"
+        ),
+        "answer_in_one_line": (
+            "No. 7.8 is the mean LENGTH OF THE WHOLE COVERAGE LIST, which the judge fills "
+            "with relationships it looked for and mostly found. Broken out by the status "
+            f"field the judge writes on every row: {pct(tot['covered'], tot['coverage_rows'])}% "
+            f"covered, {pct(tot['partially_covered'], tot['coverage_rows'])}% partially "
+            f"covered, {pct(tot['missing'], tot['coverage_rows'])}% missing."
+        ),
+        "n_papers": n_papers,
+        "n_papers_matched_to_the_released_graph": len(matched),
+        "unmatched_papers": unmatched,
+        "coverage_list": {
+            "rows_total": tot["coverage_rows"],
+            "rows_mean_per_paper": round(tot["coverage_rows"] / n_papers, 2),
+            "by_status_total": dict(status_counter.most_common()),
+            "covered": tot["covered"],
+            "partially_covered": tot["partially_covered"],
+            "missing": tot["missing"],
+            "unlabelled_or_other": tot["other_status"],
+            "missing_mean_per_paper": round(tot["missing"] / n_papers, 2),
+            "partially_covered_mean_per_paper": round(
+                tot["partially_covered"] / n_papers, 2
+            ),
+            "papers_with_at_least_one_missing": sum(1 for r in rows if r["missing"]),
+            "papers_with_zero_missing": sum(1 for r in rows if not r["missing"]),
+            "missing_max_in_one_paper": max(r["missing"] for r in rows),
+            "missing_median_per_paper": st.median(r["missing"] for r in rows),
+        },
+        "REPRODUCES_THE_RECEIPT_FIGURE": {
+            "note": (
+                "experiment_judge_item2_summary.py:144 sets missing_edges_flagged = len(cov), "
+                "i.e. the whole list. The mean below must equal the 7.77 that receipt reports; "
+                "if it does not, the two scripts are reading different inputs."
+            ),
+            "mean_len_coverage_list": round(tot["coverage_rows"] / n_papers, 2),
+            "expected_from_experiment_judge_item2_report_json": 7.77,
+            "agrees": abs(tot["coverage_rows"] / n_papers - 7.77) < 0.01,
+        },
+        "against_the_extraction_it_is_measured_on": {
+            "denominator": (
+                "EDGE-type edges the RELEASED graph holds for the same papers, keyed by "
+                "source URL -- the same construction tab:omission uses for nodes"
+            ),
+            "papers": len(matched),
+            "released_edges_total": tot_edges_matched,
+            "released_edges_mean_per_paper": round(tot_edges_matched / len(matched), 1),
+            "missing_total": missing_matched,
+            "missing_as_pct_of_released_edges": pct(missing_matched, tot_edges_matched),
+            "implied_edge_coverage_pct": pct(
+                tot_edges_matched, tot_edges_matched + missing_matched
+            ),
+            "missing_plus_partial_total": missing_matched + partial_matched,
+            "missing_plus_partial_as_pct_of_released_edges": pct(
+                missing_matched + partial_matched, tot_edges_matched
+            ),
+        },
+        "which_denominator": {
+            "note": (
+                "Two edge counts exist per judged paper and they differ. The released graph "
+                "holds more edges than the judge's own final_graph field reports, and the "
+                "paper quotes the latter (10.8) in app:judge. The released count is the "
+                "correct denominator for an omission share, because it is the artifact a "
+                "reader gets; the judge's final_graph is its own re-serialisation."
+            ),
+            "released_graph_edges_mean_per_paper": round(
+                tot_edges_matched / len(matched), 1
+            ),
+            "judge_final_graph_edges_mean_per_paper": round(
+                sum(r["judge_final_graph_edges"] for r in rows) / n_papers, 2
+            ),
+            "judge_final_graph_nodes_mean_per_paper": round(
+                sum(r["judge_final_graph_nodes"] for r in rows) / n_papers, 2
+            ),
+            "missing_as_pct_of_judge_final_graph_edges": pct(
+                tot["missing"], sum(r["judge_final_graph_edges"] for r in rows)
+            ),
+        },
+        "by_source_type": {
+            stype: {
+                "n_papers": len(g),
+                "coverage_rows_mean": round(
+                    sum(r["coverage_rows"] for r in g) / len(g), 2
+                ),
+                "missing_mean": round(sum(r["missing"] for r in g) / len(g), 2),
+                "released_edges_mean": round(
+                    sum(r["released_edges"] or 0 for r in g) / len(g), 1
+                ),
+            }
+            for stype, g in sorted(_group(rows).items(), key=lambda kv: -len(kv[1]))
+        },
+        "no_add_edges_slot": {
+            "proposed_fixes_keys_seen": dict(proposed_fix_keys.most_common()),
+            "has_add_edges_key": "add_edges" in proposed_fix_keys,
+            "reading": (
+                "The repair schema gives the judge a slot for added NODES and none for "
+                "added EDGES. A relationship the judge marks missing therefore cannot be "
+                "proposed as a repair, which is why the node-addition count (9) and the "
+                "coverage list are different instruments rather than a contradiction."
+            ),
+        },
+        "released_graph_structural_edges": {
+            "n_edge_type_edges": n_structural,
+            "n_crossing_two_source_papers": cross_paper_edges,
+            "reading": (
+                "Zero cross-paper structural edges is the single-source-by-design property "
+                "of sec:m-structural, verified here on the released substrate rather than "
+                "asserted."
+            ),
+        },
+        "LIMITS": (
+            "Every status label is the judge's own, un-adjudicated. The judge was also not "
+            "given a way to propose an edge repair, so `missing` is an opinion recorded in "
+            "a free-text inventory, not a verified omission. These counts bound the "
+            "edge-level signal; they do not measure edge recall."
+        ),
+    }
+
+    OUT.write_text(json.dumps(out, indent=1), encoding="utf-8")
+    print(json.dumps(out, indent=1))
+    print(f"\nwrote {OUT}")
+
+
+def _group(rows):
+    g = defaultdict(list)
+    for r in rows:
+        g[r["source_type"]].append(r)
+    return g
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/graph_analysis/experiment_review_release_integrity.py
+++ b/graph_analysis/experiment_review_release_integrity.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python
+"""Does the released graph carry the defects the judge found, and can a reuser re-gate it?
+
+Three reviewer questions in the 2026-08-15 round have the same shape -- they ask what a
+person who downloads the release actually gets:
+
+  C8/R45  The judge reported 108 referential-integrity findings, 42 orphans and 56
+          duplicate node pairs across 100 papers, and no repaired graph was ever rebuilt.
+          Does the released dump ship those defects? The paper does not say.
+  R46     Users need a way to tell audited content from unaudited content.
+  R114    Can a reuser re-enumerate chains at any gate setting from the dump, or are they
+          restricted to consuming the two path files we ship?
+
+None of the three needs an inference call. This script measures them directly on the
+released substrate: orphan and dangling counts computed the same way the judge's classes
+are defined, the share of the graph that any judge ever looked at, and whether every
+attribute the two gates read is actually present on every node and edge that carries it.
+
+Class B (no LLM call, no network). Run from graph_analysis/:
+
+    python -u experiment_review_release_integrity.py --judge-reports <dir>
+
+<dir> is extraction_validator/extend_try_1 from branch anthropic_judge_test.
+
+Output: graph_analysis/phase2_results/experiment_review_release_integrity_report.json
+"""
+
+import argparse
+import json
+import pickle
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+ROOT = Path(__file__).parent
+SLIM = ROOT / "phase2_results/node_attrs_slim.pkl"
+EDGES = (
+    ROOT
+    / "phase2_results/step1_load_and_parse_umapwithoutlocalsatellites/graph_edge_data.pkl"
+)
+RAW = ROOT / "phase1_rawpathsfiles/paths_hopwise_v4_edge_only.jsonl"
+OUT = ROOT / "phase2_results/experiment_review_release_integrity_report.json"
+
+EXPECTED_NODES, EXPECTED_EDGE_EDGES = 200525, 202149
+NONE_STRINGS = {"None", "none", "", "null", "NULL"}
+
+
+def pct(n, d, nd=2):
+    return round(100 * n / d, nd) if d else None
+
+
+def present(v):
+    return v is not None and str(v).strip() not in NONE_STRINGS
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--judge-reports", required=True)
+    a = ap.parse_args()
+    jdir = Path(a.judge_reports)
+    if not jdir.is_dir():
+        raise SystemExit(
+            f"FATAL: judge report directory not found: {jdir}\n"
+            "  git archive origin/anthropic_judge_test extraction_validator/extend_try_1"
+            " | tar -x -C /tmp/judge"
+        )
+    for p, how in (
+        (SLIM, "run experiment_review_prep_slim_nodes.py"),
+        (EDGES, "run phase2_step1_loadandparse.py against the FalkorDB dump"),
+        (RAW, "the released 8,954-chain path file ships with the repo"),
+    ):
+        if not p.exists():
+            raise SystemExit(f"FATAL: {p} not found. To produce it: {how}.")
+
+    slim = pickle.load(open(SLIM, "rb"))
+    if len(slim) != EXPECTED_NODES:
+        raise SystemExit(
+            f"FATAL: node table has {len(slim)}, expected {EXPECTED_NODES}. Wrong substrate."
+        )
+    nodes = {int(n): r for n, r in slim.items()}
+    edges = pickle.load(open(EDGES, "rb"))
+
+    deg = Counter()
+    dangling = 0
+    self_loops = 0
+    edge_pair_subtype = Counter()
+    n_struct = 0
+    conf_missing = 0
+    subtype_missing = 0
+    for e in edges:
+        if e.get("type") != "EDGE":
+            continue
+        n_struct += 1
+        s, t = e["source"], e["target"]
+        if s not in nodes or t not in nodes:
+            dangling += 1
+            continue
+        if s == t:
+            self_loops += 1
+        deg[s] += 1
+        deg[t] += 1
+        edge_pair_subtype[(frozenset((s, t)), e.get("subtype"))] += 1
+        if not present(e.get("confidence")):
+            conf_missing += 1
+        if not present(e.get("subtype")):
+            subtype_missing += 1
+
+    if n_struct != EXPECTED_EDGE_EDGES:
+        raise SystemExit(
+            f"FATAL: {n_struct} EDGE-type edges, expected {EXPECTED_EDGE_EDGES}."
+        )
+
+    orphans = [n for n in nodes if deg[n] == 0]
+    dup_edges = sum(v - 1 for v in edge_pair_subtype.values() if v > 1)
+
+    # exact-name duplicates within concept category (the residue app:composition reports)
+    by_name = defaultdict(list)
+    for n, r in nodes.items():
+        key = (
+            (r.get("name") or "").strip().lower(),
+            r.get("concept_category") if r.get("type") == "concept" else "intervention",
+        )
+        if key[0]:
+            by_name[key].append(n)
+    dup_groups = {k: v for k, v in by_name.items() if len(v) > 1}
+    dup_nodes_beyond_one = sum(len(v) - 1 for v in dup_groups.values())
+
+    # can a reuser re-gate? both gate attributes must be present wherever they are read
+    interventions = [n for n, r in nodes.items() if r.get("type") != "concept"]
+    intv_no_maturity = [
+        n for n in interventions if not present(nodes[n].get("intervention_maturity"))
+    ]
+    concepts_no_category = [
+        n
+        for n, r in nodes.items()
+        if r.get("type") == "concept" and not present(r.get("concept_category"))
+    ]
+    nodes_no_url = [n for n, r in nodes.items() if not present(r.get("url"))]
+
+    # audited vs unaudited share of the release
+    judged_urls = set()
+    for p in sorted(jdir.glob("*.json")):
+        if p.name in ("summary.json", "errors.json"):
+            continue
+        r = json.loads(p.read_text(encoding="utf-8"))
+        if r.get("url"):
+            judged_urls.add(r["url"])
+    nodes_judged = sum(1 for r in nodes.values() if r.get("url") in judged_urls)
+
+    chain_nodes = set()
+    with open(RAW, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                chain_nodes.update(int(x) for x in json.loads(line)["path"])
+
+    out = {
+        "experiment": "released-graph defect inventory and re-gateability (C8/R45/R46/R114)",
+        "substrate": {
+            "nodes": len(nodes),
+            "structural_edges": n_struct,
+            "note": "the un-merged 200,525-node graph this paper reports on",
+        },
+        "does_the_release_ship_the_defect_classes_the_judge_found": {
+            "question": (
+                "The judge reported these classes on 100 papers' extraction JSON. No "
+                "repaired graph was rebuilt, so the released dump should still carry them. "
+                "Measured here on the dump itself, corpus-wide."
+            ),
+            "orphan_nodes_zero_structural_edges": len(orphans),
+            "orphan_pct_of_graph": pct(len(orphans), len(nodes)),
+            "dangling_edges_endpoint_not_in_node_table": dangling,
+            "self_loops": self_loops,
+            "duplicate_edges_same_pair_same_relation_type": dup_edges,
+            "exact_name_duplicate_groups_within_category": len(dup_groups),
+            "exact_name_duplicate_nodes_beyond_one_per_group": dup_nodes_beyond_one,
+            "cross_check": (
+                "app:composition reports 448 groups and 1,140 redundant nodes from "
+                "experiment_J6_merge_approx_v2_report.json; these are re-derived here."
+            ),
+        },
+        "can_a_reuser_re_enumerate_at_any_gate": {
+            "question": "R114 -- is the dump enough, or must a reuser consume our path files?",
+            "structural_edges_missing_a_confidence_value": conf_missing,
+            "structural_edges_missing_a_relation_type": subtype_missing,
+            "intervention_nodes_missing_a_maturity_value": len(intv_no_maturity),
+            "concept_nodes_missing_a_category": len(concepts_no_category),
+            "nodes_missing_a_source_url": len(nodes_no_url),
+            "answer": (
+                "Yes if all five counts above are zero: every attribute the two gates read "
+                "is on the dump, so any gate setting is re-enumerable from it and the path "
+                "files are a convenience, not the only access path."
+            ),
+            "verdict_all_gate_attributes_present": (
+                conf_missing == 0
+                and len(intv_no_maturity) == 0
+                and len(concepts_no_category) == 0
+            ),
+        },
+        "audited_vs_unaudited_content": {
+            "question": "R46 -- can a user tell which part of the release anyone checked?",
+            "judged_source_documents": len(judged_urls),
+            "nodes_from_judged_documents": nodes_judged,
+            "nodes_from_judged_documents_pct": pct(nodes_judged, len(nodes)),
+            "nodes_never_seen_by_any_judge": len(nodes) - nodes_judged,
+            "reading": (
+                "Under one percent of the released nodes were looked at by the judge, and "
+                "no node was looked at by a human. The release should carry a per-node flag "
+                "for this rather than leaving it to the paper's population table."
+            ),
+        },
+        "chain_coverage_of_the_graph": {
+            "nodes_appearing_in_at_least_one_enumerated_chain": len(chain_nodes),
+            "pct_of_graph": pct(len(chain_nodes), len(nodes)),
+            "reading": (
+                "The chain set touches a small share of the released graph. A reuser who "
+                "consumes only the path files is consuming that share."
+            ),
+        },
+        "LIMITS": (
+            "Structural integrity only. An orphan here is a node with no structural edge in "
+            "the dump, which is the judge's own orphan definition applied corpus-wide; it is "
+            "not the same measurement as the judge's per-paper count and the two should not "
+            "be added together."
+        ),
+    }
+
+    OUT.write_text(json.dumps(out, indent=1), encoding="utf-8")
+    print(json.dumps(out, indent=1))
+    print(f"\nwrote {OUT}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/graph_analysis/phase2_results/experiment_paper_claim_audit.json
+++ b/graph_analysis/phase2_results/experiment_paper_claim_audit.json
@@ -1,7 +1,7 @@
 {
  "audit": "paperA_draft_v2.tex quantitative claims vs raw data",
- "n_claims_checked": 218,
- "n_pass": 218,
+ "n_claims_checked": 235,
+ "n_pass": 235,
  "n_fail": 0,
  "claims": [
   {
@@ -677,109 +677,25 @@
    "note": ""
   },
   {
-   "claim": "grader ICC(2,1) pre-repair",
-   "in_draft": 0.921,
-   "recomputed_from_raw": 0.921,
-   "verdict": "PASS",
-   "note": ""
-  },
-  {
-   "claim": "grader ICC(2,1) post-repair",
-   "in_draft": 0.151,
-   "recomputed_from_raw": 0.151,
-   "verdict": "PASS",
-   "note": ""
-  },
-  {
-   "claim": "grader ICC(2,k) pre-repair",
-   "in_draft": 0.972,
-   "recomputed_from_raw": 0.972,
-   "verdict": "PASS",
-   "note": ""
-  },
-  {
-   "claim": "grader ICC(2,k) post-repair",
-   "in_draft": 0.348,
-   "recomputed_from_raw": 0.348,
-   "verdict": "PASS",
-   "note": ""
-  },
-  {
-   "claim": "grader Krippendorff alpha pre-repair",
-   "in_draft": 0.917,
-   "recomputed_from_raw": 0.917,
-   "verdict": "PASS",
-   "note": ""
-  },
-  {
-   "claim": "grader Krippendorff alpha post-repair",
-   "in_draft": 0.043,
-   "recomputed_from_raw": 0.043,
-   "verdict": "PASS",
-   "note": ""
-  },
-  {
    "claim": "grader claude-opus-4-5: paired pre/post rows",
    "in_draft": 95,
    "recomputed_from_raw": 95,
    "verdict": "PASS",
-   "note": ""
-  },
-  {
-   "claim": "grader claude-opus-4-5: files seen",
-   "in_draft": 101,
-   "recomputed_from_raw": 101,
-   "verdict": "PASS",
-   "note": ""
-  },
-  {
-   "claim": "grader claude-opus-4-5: distinct JSON shapes",
-   "in_draft": 13,
-   "recomputed_from_raw": 13,
-   "verdict": "PASS",
-   "note": "the agent-session design of app:judgeprompt is why the shape drifts within one grader's output; 1 shape -> a paired score on every file"
+   "note": "printed in tab:populations-master as the 95/95/13 row; the per-grader session diagnostics behind those denominators left the paper 2026-08-16"
   },
   {
    "claim": "grader gemini-3-pro: paired pre/post rows",
    "in_draft": 13,
    "recomputed_from_raw": 13,
    "verdict": "PASS",
-   "note": ""
-  },
-  {
-   "claim": "grader gemini-3-pro: files seen",
-   "in_draft": 100,
-   "recomputed_from_raw": 100,
-   "verdict": "PASS",
-   "note": ""
-  },
-  {
-   "claim": "grader gemini-3-pro: distinct JSON shapes",
-   "in_draft": 12,
-   "recomputed_from_raw": 12,
-   "verdict": "PASS",
-   "note": "the agent-session design of app:judgeprompt is why the shape drifts within one grader's output; 1 shape -> a paired score on every file"
+   "note": "printed in tab:populations-master as the 95/95/13 row; the per-grader session diagnostics behind those denominators left the paper 2026-08-16"
   },
   {
    "claim": "grader third_grader_gpt-5.1: paired pre/post rows",
    "in_draft": 95,
    "recomputed_from_raw": 95,
    "verdict": "PASS",
-   "note": ""
-  },
-  {
-   "claim": "grader third_grader_gpt-5.1: files seen",
-   "in_draft": 95,
-   "recomputed_from_raw": 95,
-   "verdict": "PASS",
-   "note": ""
-  },
-  {
-   "claim": "grader third_grader_gpt-5.1: distinct JSON shapes",
-   "in_draft": 1,
-   "recomputed_from_raw": 1,
-   "verdict": "PASS",
-   "note": "the agent-session design of app:judgeprompt is why the shape drifts within one grader's output; 1 shape -> a paired score on every file"
+   "note": "printed in tab:populations-master as the 95/95/13 row; the per-grader session diagnostics behind those denominators left the paper 2026-08-16"
   },
   {
    "claim": "judged papers: extracted nodes",
@@ -792,13 +708,6 @@
    "claim": "judge additions as pct of extracted nodes",
    "in_draft": 0.6,
    "recomputed_from_raw": 0.6,
-   "verdict": "PASS",
-   "note": ""
-  },
-  {
-   "claim": "judge implied coverage pct",
-   "in_draft": 99.4,
-   "recomputed_from_raw": 99.4,
    "verdict": "PASS",
    "note": ""
   },
@@ -817,18 +726,228 @@
    "note": ""
   },
   {
-   "claim": "grader implied coverage pct",
-   "in_draft": 77.7,
-   "recomputed_from_raw": 77.7,
-   "verdict": "PASS",
-   "note": ""
-  },
-  {
    "claim": "missed concepts total",
    "in_draft": 216,
    "recomputed_from_raw": 216,
    "verdict": "PASS",
    "note": ""
+  },
+  {
+   "claim": "coverage list: rows over the 100 judged papers",
+   "in_draft": 777,
+   "recomputed_from_raw": 777,
+   "verdict": "PASS",
+   "note": ""
+  },
+  {
+   "claim": "coverage list: covered",
+   "in_draft": 328,
+   "recomputed_from_raw": 328,
+   "verdict": "PASS",
+   "note": ""
+  },
+  {
+   "claim": "coverage list: partially covered",
+   "in_draft": 146,
+   "recomputed_from_raw": 146,
+   "verdict": "PASS",
+   "note": ""
+  },
+  {
+   "claim": "coverage list: missing",
+   "in_draft": 302,
+   "recomputed_from_raw": 302,
+   "verdict": "PASS",
+   "note": ""
+  },
+  {
+   "claim": "coverage list: missing per paper",
+   "in_draft": 3.02,
+   "recomputed_from_raw": 3.02,
+   "verdict": "PASS",
+   "note": ""
+  },
+  {
+   "claim": "coverage list: papers with at least one missing",
+   "in_draft": 90,
+   "recomputed_from_raw": 90,
+   "verdict": "PASS",
+   "note": ""
+  },
+  {
+   "claim": "judged papers: structural edges in the released graph",
+   "in_draft": 1667,
+   "recomputed_from_raw": 1667,
+   "verdict": "PASS",
+   "note": ""
+  },
+  {
+   "claim": "judged papers: released edges per paper",
+   "in_draft": 16.7,
+   "recomputed_from_raw": 16.7,
+   "verdict": "PASS",
+   "note": "app:judge prints this beside the judge's own final_graph mean of 10.8"
+  },
+  {
+   "claim": "missing relationships as pct of extracted edges",
+   "in_draft": 18.1,
+   "recomputed_from_raw": 18.1,
+   "verdict": "PASS",
+   "note": "the abstract's third omission rate"
+  },
+  {
+   "claim": "same count against the judge's own edge total",
+   "in_draft": 28.1,
+   "recomputed_from_raw": 28.1,
+   "verdict": "PASS",
+   "note": ""
+  },
+  {
+   "claim": "judge final_graph edges per paper",
+   "in_draft": 10.76,
+   "recomputed_from_raw": 10.76,
+   "verdict": "PASS",
+   "note": ""
+  },
+  {
+   "claim": "judge repair schema has no add_edges slot",
+   "in_draft": false,
+   "recomputed_from_raw": false,
+   "verdict": "PASS",
+   "note": "app:judgeprompt and sec:r-judge give this absence as the explanation for the gap between the node-addition count and the coverage list"
+  },
+  {
+   "claim": "structural edges crossing two source papers",
+   "in_draft": 0,
+   "recomputed_from_raw": 0,
+   "verdict": "PASS",
+   "note": "single-source-by-design, sec:m-structural"
+  },
+  {
+   "claim": "collapse: dropped paths that are contiguous sub-paths of their container",
+   "in_draft": 0.0,
+   "recomputed_from_raw": 0.0,
+   "verdict": "PASS",
+   "note": "sec:m-reporting no longer describes the step as dropping sub-paths already counted inside a longer path; this is why"
+  },
+  {
+   "claim": "collapse: drops differing only by chords",
+   "in_draft": 21.7,
+   "recomputed_from_raw": 21.7,
+   "verdict": "PASS",
+   "note": ""
+  },
+  {
+   "claim": "collapse: drops touching a node the container lacks",
+   "in_draft": 78.3,
+   "recomputed_from_raw": 78.3,
+   "verdict": "PASS",
+   "note": ""
+  },
+  {
+   "claim": "collapse: drops ending at an intervention the container lacks",
+   "in_draft": 28.0,
+   "recomputed_from_raw": 28.0,
+   "verdict": "PASS",
+   "note": ""
+  },
+  {
+   "claim": "collapse: distinct risk-to-intervention pairs lost",
+   "in_draft": 579,
+   "recomputed_from_raw": 579,
+   "verdict": "PASS",
+   "note": ""
+  },
+  {
+   "claim": "collapse: pct of raw R-I pairs lost",
+   "in_draft": 18.0,
+   "recomputed_from_raw": 18.0,
+   "verdict": "PASS",
+   "note": ""
+  },
+  {
+   "claim": "released graph: orphan nodes",
+   "in_draft": 0,
+   "recomputed_from_raw": 0,
+   "verdict": "PASS",
+   "note": ""
+  },
+  {
+   "claim": "released graph: dangling edges",
+   "in_draft": 0,
+   "recomputed_from_raw": 0,
+   "verdict": "PASS",
+   "note": ""
+  },
+  {
+   "claim": "released graph: self-loops",
+   "in_draft": 0,
+   "recomputed_from_raw": 0,
+   "verdict": "PASS",
+   "note": ""
+  },
+  {
+   "claim": "released graph: duplicate edges",
+   "in_draft": 1,
+   "recomputed_from_raw": 1,
+   "verdict": "PASS",
+   "note": ""
+  },
+  {
+   "claim": "released graph: exact-name duplicate groups",
+   "in_draft": 448,
+   "recomputed_from_raw": 448,
+   "verdict": "PASS",
+   "note": ""
+  },
+  {
+   "claim": "released graph: exact-name duplicate nodes beyond one per group",
+   "in_draft": 1140,
+   "recomputed_from_raw": 1140,
+   "verdict": "PASS",
+   "note": ""
+  },
+  {
+   "claim": "every gate attribute present on the released graph",
+   "in_draft": true,
+   "recomputed_from_raw": true,
+   "verdict": "PASS",
+   "note": "sec:m-repro claims a reuser can re-enumerate at any gate setting from the dump alone, which is only true while this holds"
+  },
+  {
+   "claim": "released nodes from a judged document",
+   "in_draft": 1617,
+   "recomputed_from_raw": 1617,
+   "verdict": "PASS",
+   "note": ""
+  },
+  {
+   "claim": "released nodes from a judged document, pct",
+   "in_draft": 0.81,
+   "recomputed_from_raw": 0.81,
+   "verdict": "PASS",
+   "note": ""
+  },
+  {
+   "claim": "recovery: judgeable failed extractions",
+   "in_draft": 441,
+   "recomputed_from_raw": 441,
+   "verdict": "PASS",
+   "note": ""
+  },
+  {
+   "claim": "recovery: attempts producing a non-empty graph",
+   "in_draft": 23,
+   "recomputed_from_raw": 23,
+   "verdict": "PASS",
+   "note": ""
+  },
+  {
+   "claim": "recovery rate pct",
+   "in_draft": 5.2,
+   "recomputed_from_raw": 5.2,
+   "verdict": "PASS",
+   "note": "sec:m-recovery prints this from 2026-08-16; it used to say 'not at a useful rate' with no number. The '~60 of ~400' in older project notes divides two disjoint populations and is wrong"
   },
   {
    "claim": "UMAP k=40 silhouette in its own space",

--- a/graph_analysis/phase2_results/experiment_review_containment_semantics_report.json
+++ b/graph_analysis/phase2_results/experiment_review_containment_semantics_report.json
@@ -1,0 +1,92 @@
+{
+ "experiment": "semantics of the 70% sub-path collapse (R22/R23)",
+ "question": "The containment rule compares node sets. Reviewers asked what it does to edge identity, order, and to traversals that are arguments in their own right.",
+ "reproduction_check": {
+  "raw_paths": 8954,
+  "kept": 2772,
+  "dropped": 6182,
+  "released_deduped_file": 2772,
+  "keeps_the_same_set_as_the_released_file": true,
+  "note": "The script exits non-zero unless the re-implementation reproduces the released chain set exactly, so every number below describes the substrate the paper reports on."
+ },
+ "node_set_relation": {
+  "node_set_is_subset_of_container": 1342,
+  "partial_overlap_only": 4840,
+  "pct_subset": 21.7,
+  "pct_partial_overlap_only": 78.3,
+  "cross_check_novel_node_share_pct": 78.3,
+  "cross_check_note": "experiment_review_gate_sensitivity_report.json -> containment_losslessness reports 78.3% of dropped paths carrying at least one node their container lacks. That is the same quantity as pct_partial_overlap_only and must agree."
+ },
+ "order_relation": {
+  "non_contiguous_subsequence": 846,
+  "not_a_subsequence_reordered_or_branching": 5336,
+  "pct_contiguous_sub_path": 0.0,
+  "reading": "A contiguous sub-path over the same node order is a restatement by construction: the container traces it and continues. Those drops are unambiguously safe. Everything else is where an annotator would have to decide, and that share is what the paper should state."
+ },
+ "edge_identity": {
+  "traverses_at_least_one_hop_the_container_never_traverses": 6182,
+  "unmatched_hops_are_all_chords_across_container_nodes": 1342,
+  "at_least_one_unmatched_hop_touches_a_node_the_container_lacks": 4840,
+  "pct_with_an_unmatched_hop": 100.0,
+  "pct_chords_only": 21.7,
+  "pct_touching_a_node_the_container_lacks": 78.3,
+  "unmatched_hop_relation_types": {
+   "validated_by": 4354,
+   "motivates": 3683,
+   "implemented_by": 3036,
+   "caused_by": 2595,
+   "mitigated_by": 1289,
+   "enabled_by": 958,
+   "addressed_by": 409,
+   "refined_by": 145,
+   "specified_by": 51,
+   "required_by": 50,
+   "enables": 10,
+   "exacerbated_by": 3,
+   "mitigates": 2
+  },
+  "reading": "This is the reviewers' objection made numeric, and it splits two ways. Every dropped path traverses at least one relation its container does not, so no drop is a strict re-walk. But where the unmatched hops are chords across nodes the container also holds, the two chains trace the same material at different granularity, and calling the drop a repeat is defensible. The other class is a genuine departure."
+ },
+ "does_the_drop_remove_a_distinct_remedy": {
+  "ends_at_an_intervention_the_container_also_contains": 4451,
+  "ends_at_an_intervention_absent_from_the_container": 1731,
+  "pct_ending_at_an_intervention_the_container_lacks": 28.0,
+  "distinct_risk_to_intervention_pairs_raw": 3222,
+  "distinct_risk_to_intervention_pairs_kept": 2643,
+  "distinct_pairs_lost_to_the_collapse": 579,
+  "pct_of_raw_pairs_lost": 18.0,
+  "reading": "This is the sharpest structural form of the reviewers' question. A dropped chain that terminates at an intervention the kept chain never reaches proposes a remedy the reporting unit no longer carries for that risk. The pair counts must agree with experiment_paper_claim_audit.json -> distinct_ri_node_pairs (raw 3,222 / deduped 2,643)."
+ },
+ "shared_prefix_with_container": {
+  "length_histogram_nodes": {
+   "0": 1099,
+   "1": 1424,
+   "2": 271,
+   "3": 683,
+   "4": 1039,
+   "5": 604,
+   "6": 713,
+   "7": 173,
+   "8": 115,
+   "9": 27,
+   "10": 26,
+   "11": 2,
+   "12": 3,
+   "13": 2,
+   "14": 1
+  },
+  "pct_sharing_the_risk_root": 82.2,
+  "reading": "Enumeration is risk-rooted, so a shared prefix is expected; the length at which two chains diverge is where one paper's argument branches."
+ },
+ "novel_node_stage_coverage": {
+  "novel_nodes_are_all_in_stages_the_container_already_has": 4811,
+  "novel_node_introduces_a_stage_the_container_lacks": 29
+ },
+ "parallel_edges_in_the_released_graph": {
+  "node_pairs_carrying_more_than_one_relation_type": 63,
+  "reading": "If this is zero, the collapse cannot conflate two different relations between the same pair of nodes, and the edge-identity question reduces to which node pairs are traversed."
+ },
+ "empty_paths_dropped": 0,
+ "HEADLINE": "Of 6182 dropped paths, 0.0% are contiguous sub-paths of the chain that displaced them; 100.0% traverse at least one relation the kept chain does not, and 28.0% end at an intervention the kept chain never reaches. 579 distinct risk-to-intervention pairs (18.0% of the raw set) are not represented in the reporting unit at all.",
+ "LIMITS": "Structural only. Two traversals over disjoint hops may still be the same argument, and two over identical hops may be read differently. Settling that needs the annotation study of OPEN_ITEMS.md S4."
+}

--- a/graph_analysis/phase2_results/experiment_review_edge_coverage_report.json
+++ b/graph_analysis/phase2_results/experiment_review_edge_coverage_report.json
@@ -1,0 +1,125 @@
+{
+ "experiment": "judge edge-coverage list, broken out by status (S10)",
+ "question": "The paper quotes a mean of 7.8 flagged relationships per paper against a mean audited extraction of 10.8 edges, which reads as an edge-omission signal of the same order as the extraction. Is it one?",
+ "answer_in_one_line": "No. 7.8 is the mean LENGTH OF THE WHOLE COVERAGE LIST, which the judge fills with relationships it looked for and mostly found. Broken out by the status field the judge writes on every row: 42.2% covered, 18.8% partially covered, 38.9% missing.",
+ "n_papers": 100,
+ "n_papers_matched_to_the_released_graph": 100,
+ "unmatched_papers": [],
+ "coverage_list": {
+  "rows_total": 777,
+  "rows_mean_per_paper": 7.77,
+  "by_status_total": {
+   "covered": 328,
+   "missing": 302,
+   "partially_covered": 146,
+   "covered_abstractly": 1
+  },
+  "covered": 328,
+  "partially_covered": 146,
+  "missing": 302,
+  "unlabelled_or_other": 1,
+  "missing_mean_per_paper": 3.02,
+  "partially_covered_mean_per_paper": 1.46,
+  "papers_with_at_least_one_missing": 90,
+  "papers_with_zero_missing": 10,
+  "missing_max_in_one_paper": 11,
+  "missing_median_per_paper": 2.5
+ },
+ "REPRODUCES_THE_RECEIPT_FIGURE": {
+  "note": "experiment_judge_item2_summary.py:144 sets missing_edges_flagged = len(cov), i.e. the whole list. The mean below must equal the 7.77 that receipt reports; if it does not, the two scripts are reading different inputs.",
+  "mean_len_coverage_list": 7.77,
+  "expected_from_experiment_judge_item2_report_json": 7.77,
+  "agrees": true
+ },
+ "against_the_extraction_it_is_measured_on": {
+  "denominator": "EDGE-type edges the RELEASED graph holds for the same papers, keyed by source URL -- the same construction tab:omission uses for nodes",
+  "papers": 100,
+  "released_edges_total": 1667,
+  "released_edges_mean_per_paper": 16.7,
+  "missing_total": 302,
+  "missing_as_pct_of_released_edges": 18.1,
+  "implied_edge_coverage_pct": 84.7,
+  "missing_plus_partial_total": 448,
+  "missing_plus_partial_as_pct_of_released_edges": 26.9
+ },
+ "which_denominator": {
+  "note": "Two edge counts exist per judged paper and they differ. The released graph holds more edges than the judge's own final_graph field reports, and the paper quotes the latter (10.8) in app:judge. The released count is the correct denominator for an omission share, because it is the artifact a reader gets; the judge's final_graph is its own re-serialisation.",
+  "released_graph_edges_mean_per_paper": 16.7,
+  "judge_final_graph_edges_mean_per_paper": 10.76,
+  "judge_final_graph_nodes_mean_per_paper": 15.98,
+  "missing_as_pct_of_judge_final_graph_edges": 28.1
+ },
+ "by_source_type": {
+  "lesswrong": {
+   "n_papers": 28,
+   "coverage_rows_mean": 7.25,
+   "missing_mean": 2.89,
+   "released_edges_mean": 14.0
+  },
+  "alignmentforum": {
+   "n_papers": 21,
+   "coverage_rows_mean": 8.52,
+   "missing_mean": 3.38,
+   "released_edges_mean": 19.8
+  },
+  "blogs": {
+   "n_papers": 15,
+   "coverage_rows_mean": 7.4,
+   "missing_mean": 2.53,
+   "released_edges_mean": 15.3
+  },
+  "arxiv": {
+   "n_papers": 11,
+   "coverage_rows_mean": 10.09,
+   "missing_mean": 3.27,
+   "released_edges_mean": 20.7
+  },
+  "eaforum": {
+   "n_papers": 11,
+   "coverage_rows_mean": 7.82,
+   "missing_mean": 3.55,
+   "released_edges_mean": 19.6
+  },
+  "arbital": {
+   "n_papers": 6,
+   "coverage_rows_mean": 4.5,
+   "missing_mean": 1.83,
+   "released_edges_mean": 9.3
+  },
+  "special_docs": {
+   "n_papers": 4,
+   "coverage_rows_mean": 7.75,
+   "missing_mean": 3.25,
+   "released_edges_mean": 16.8
+  },
+  "aisafety.info": {
+   "n_papers": 2,
+   "coverage_rows_mean": 6.5,
+   "missing_mean": 2.5,
+   "released_edges_mean": 11.5
+  },
+  "youtube": {
+   "n_papers": 2,
+   "coverage_rows_mean": 8.0,
+   "missing_mean": 4.0,
+   "released_edges_mean": 19.0
+  }
+ },
+ "no_add_edges_slot": {
+  "proposed_fixes_keys_seen": {
+   "add_nodes": 100,
+   "merges": 100,
+   "deletions": 100,
+   "edge_deletions": 100,
+   "change_node_fields": 100
+  },
+  "has_add_edges_key": false,
+  "reading": "The repair schema gives the judge a slot for added NODES and none for added EDGES. A relationship the judge marks missing therefore cannot be proposed as a repair, which is why the node-addition count (9) and the coverage list are different instruments rather than a contradiction."
+ },
+ "released_graph_structural_edges": {
+  "n_edge_type_edges": 202149,
+  "n_crossing_two_source_papers": 0,
+  "reading": "Zero cross-paper structural edges is the single-source-by-design property of sec:m-structural, verified here on the released substrate rather than asserted."
+ },
+ "LIMITS": "Every status label is the judge's own, un-adjudicated. The judge was also not given a way to propose an edge repair, so `missing` is an opinion recorded in a free-text inventory, not a verified omission. These counts bound the edge-level signal; they do not measure edge recall."
+}

--- a/graph_analysis/phase2_results/experiment_review_release_integrity_report.json
+++ b/graph_analysis/phase2_results/experiment_review_release_integrity_report.json
@@ -1,0 +1,43 @@
+{
+ "experiment": "released-graph defect inventory and re-gateability (C8/R45/R46/R114)",
+ "substrate": {
+  "nodes": 200525,
+  "structural_edges": 202149,
+  "note": "the un-merged 200,525-node graph this paper reports on"
+ },
+ "does_the_release_ship_the_defect_classes_the_judge_found": {
+  "question": "The judge reported these classes on 100 papers' extraction JSON. No repaired graph was rebuilt, so the released dump should still carry them. Measured here on the dump itself, corpus-wide.",
+  "orphan_nodes_zero_structural_edges": 0,
+  "orphan_pct_of_graph": 0.0,
+  "dangling_edges_endpoint_not_in_node_table": 0,
+  "self_loops": 0,
+  "duplicate_edges_same_pair_same_relation_type": 1,
+  "exact_name_duplicate_groups_within_category": 448,
+  "exact_name_duplicate_nodes_beyond_one_per_group": 1140,
+  "cross_check": "app:composition reports 448 groups and 1,140 redundant nodes from experiment_J6_merge_approx_v2_report.json; these are re-derived here."
+ },
+ "can_a_reuser_re_enumerate_at_any_gate": {
+  "question": "R114 -- is the dump enough, or must a reuser consume our path files?",
+  "structural_edges_missing_a_confidence_value": 0,
+  "structural_edges_missing_a_relation_type": 0,
+  "intervention_nodes_missing_a_maturity_value": 0,
+  "concept_nodes_missing_a_category": 0,
+  "nodes_missing_a_source_url": 0,
+  "answer": "Yes if all five counts above are zero: every attribute the two gates read is on the dump, so any gate setting is re-enumerable from it and the path files are a convenience, not the only access path.",
+  "verdict_all_gate_attributes_present": true
+ },
+ "audited_vs_unaudited_content": {
+  "question": "R46 -- can a user tell which part of the release anyone checked?",
+  "judged_source_documents": 100,
+  "nodes_from_judged_documents": 1617,
+  "nodes_from_judged_documents_pct": 0.81,
+  "nodes_never_seen_by_any_judge": 198908,
+  "reading": "Under one percent of the released nodes were looked at by the judge, and no node was looked at by a human. The release should carry a per-node flag for this rather than leaving it to the paper's population table."
+ },
+ "chain_coverage_of_the_graph": {
+  "nodes_appearing_in_at_least_one_enumerated_chain": 19073,
+  "pct_of_graph": 9.51,
+  "reading": "The chain set touches a small share of the released graph. A reuser who consumes only the path files is consuming that share."
+ },
+ "LIMITS": "Structural integrity only. An orphan here is a node with no structural edge in the dump, which is the judge's own orphan definition applied corpus-wide; it is not the same measurement as the judge's per-paper count and the two should not be added together."
+}

--- a/paper/OPEN_ITEMS.md
+++ b/paper/OPEN_ITEMS.md
@@ -13,6 +13,12 @@ each so the two never drift apart.
 **Written 2026-08-15**, renamed from `STUDY_LIST_2026-08-15.md` and made canonical the same
 day. Every entry is scoped to the point where it could be started the same day.
 
+**Amended 2026-08-16** after an execution pass that closed S10, C2-C9, every
+unanimous cut-list row and the language items: manuscript commit `337d033` in
+`AISafetyIntervention_PaperA_shared`, analysis issues #156 / #157 with PRs #158 /
+#159. Claim audit **235/235**. What remains below needs money, a person, or a team
+decision -- nothing left on this list is blocked on writing.
+
 **Amended 2026-08-15 PM** after an independent three-model review round (Claude Opus 5,
 GPT-5.6 Sol, Gemini 3.1 Pro; conference and workshop bars; reviews and usage receipts in
 `paper/reviews_2026-08-15/`, script `paper/review_multi_model.py`). Each model received
@@ -35,7 +41,7 @@ extraction cost measurement (issue #152, PR #154) and the stage-separability pro
 | Internal reviews, W- and V-tags cited throughout this file | `REVIEW_neurips_scored_plus_style_shared_2026-08-14.md` (W1–W23), `REVIEW_workshop_scored_plus_style_shared_2026-08-15.md` (V1–V10, H1–H4) | What was already implemented against them: `REVIEW_RESPONSE_2026-08-14.md` |
 | External three-model round | `reviews_2026-08-15/` — six `.md` + six `.meta.json` | Usage, wall-clock and stop reason per job in the meta files |
 | Re-running that round | `review_multi_model.py` (`--smoke` first) | Verified model IDs `claude-opus-5`, `gpt-5.6-sol`, `models/gemini-3.1-pro-preview` (there is no non-preview `gemini-3.1-pro`). Keys read from three different projects' `.env` files; paths are constants at the top of the script. Actual cost of the full six-job run: **$2.53**, 2.5 min wall-clock, nothing near the 64k output cap. **This repo is public**, so the two machine-specific paths are environment-supplied and fail fast if unset — export `REVIEW_PAPER_PDF` (the compiled PDF) and `REVIEW_ANTHROPIC_ENV` (the `.env` holding `ANTHROPIC_API_KEY`) before running. The OpenAI and Gemini key files are repo-relative |
-| Verification loop after any manuscript edit | `asciify_tex.py` → `texlint.py` → `graph_analysis/experiment_paper_claim_audit.py` | Expect **218/218**, not the 42/42 several docs still say — see C9 |
+| Verification loop after any manuscript edit | `asciify_tex.py` → `texlint.py` → `graph_analysis/experiment_paper_claim_audit.py` | Expect **235/235** (2026-08-16). The stale 42/42 references are fixed; C9 is closed |
 
 ## 🔴 Locked decisions — do not revert
 
@@ -55,7 +61,10 @@ wrongly at least once.
 - **The reporting unit is the 2,772 de-duplicated chain set**, never the raw 8,954.
 - **Intervention maturity is LLM-assigned and un-adjudicated** — composition, never a
   measured rate.
-- **The extraction is one schema-constrained call per document. Not agentic.**
+- **The extraction is one schema-*prompted* request per document. Not agentic.** Conformance
+  is prompt-enforced with no structured-output constraint, so "schema-constrained" was an
+  overclaim and left the manuscript on 2026-08-16 (C2). A request may cost up to three API
+  attempts; that is a retry, not a second request, and never a conversation.
 - **The two non-reproducing quantities** (88% race framing, 51-of-100 isolation) come from
   this project's own earlier internal pass, not from published work. No citation exists and
   none can be manufactured.
@@ -147,7 +156,7 @@ boundaries, which is where the existing probe's errors already fall.
 **Human involvement: none for the model arm.** Adding one human annotator over the same
 50 documents (see S5) turns it into the full three-way study the reviewer asked for.
 
-### S10. Edge-coverage reconciliation — NEW 2026-08-15 PM, and the most consequential new finding
+### S10. Edge-coverage reconciliation — DONE 2026-08-16 (issue #156, PR #158)
 **Answers** a gap none of the earlier reviews caught. GPT-5.6 Sol raises it at both bars:
 the judge's coverage list flags **a mean of 7.8 missing relationships per paper** against a
 mean audited extraction of **10.8 edges** — i.e. a possible edge-level omission signal of
@@ -172,9 +181,15 @@ explanation and should be stated as one, not left implicit.
 released graph. **Human involvement: none** unless the team wants the flagged relationships
 manually inspected, which folds into S4/S5.
 
-**Why it is Tier 1 despite being bookkeeping.** It is free, it is the only item on this list
-that could move a headline number in the abstract, and leaving it unaddressed is the
-cheapest way to lose a reviewer who reads the appendices.
+**Result.** The 7.8 was never an omission count: it is `len(coverage list)` from
+`experiment_judge_item2_summary.py:144`, and 42.2% of its 777 rows are marked *covered*.
+By status: 328 covered / 146 partially / 302 missing = **3.02 missing per paper**, in 90
+of 100 papers. Against the 1,667 structural edges the released graph holds for those
+papers, **18.1%** — where node-level omission reads 0.6%. So the alarm rested on a
+mislabelled quantity **and** the corrected figure is still the paper's largest
+unreported coverage signal. In the manuscript: three omission rates in the abstract,
+a third row and a unit column in `tab:omission`, the no-`add_edges`-slot explanation
+stated rather than implied, and "implied coverage of 99.4%" deleted.
 
 ---
 
@@ -281,7 +296,7 @@ how badly a reviewer reacts to finding it.
 | # | Correction | Agreement | Verified |
 |---|---|---|---|
 | C1 | The eight rendered `\OPEN{[GAP: ...]}` blocks (enumerated below), four of which are notes addressed to co-authors ("Open for the team to decide", "Do not populate from git history alone"). Every model at both bars calls the submission unfinished on this basis alone, and two say nothing else matters until it is fixed | **3/3** | 8 blocks render |
-| C9 | **Five stale "42/42" claim-audit references** — `REPRODUCE.md:44`, `NEXT_STEPS_REWRITE_2026-08-14.md:17` and `:369`, `NEXT_STEPS_2026-08-11.md:20` and `:173` — against the manuscript's current 218/218. `REPRODUCE.md` is the file a reviewer actually runs, so the mismatch reads as a broken audit. Not raised by any model (they never saw the repo); found in-session 2026-08-15 | in-session | 5 references confirmed |
+| C9 **DONE** | **Five stale "42/42" claim-audit references** — `REPRODUCE.md:44`, `NEXT_STEPS_REWRITE_2026-08-14.md:17` and `:369`, `NEXT_STEPS_2026-08-11.md:20` and `:173` — against the manuscript's current 218/218. `REPRODUCE.md` is the file a reviewer actually runs, so the mismatch reads as a broken audit. Not raised by any model (they never saw the repo); found in-session 2026-08-15 | in-session | 5 references confirmed |
 
 **C1 in full — the eight blocks, and who can close each:**
 
@@ -295,13 +310,13 @@ how badly a reviewer reacts to finding it.
 | Acknowledgments | author list, affiliations, contribution statement (gate G15) | team |
 | Use of AI Assistance | scope of the drafting claim | settles with G15, same conversation |
 | `app:clusters` | publish 20 representative nodes per cluster | ships with the release, or moots itself if `app:clusters` is cut per the cut list |
-| C2 | "schema-constrained" (×4, incl. abstract and Fig. 1 caption) while `sec:m-extraction` concedes conformance is prompt-enforced with no structured-output constraint. Use "schema-prompted" | 1/3 | 4 occurrences, contradiction confirmed |
-| C3 | `sec:m-repro` "a re-run reproduces the same model generation" (L627) reads against `sec:m-extraction` "runs are not bit-reproducible" (L339). Both render; the first invites the wrong reading | 1/3 | both lines confirmed |
-| C4 | `tab:gates` marks the maturity-$\geq 3$ row "(deployed)" while the rubric reserves *deployed* for maturity 4. The intent is "the deployed setting"; relabel so it cannot be read as the maturity band | 1/3 | confirmed |
-| C5 | `refs.bib` carries 29 non-standard annotation fields, including "Verified 2026-08-15" and per-entry mini-summaries. Move to a source-verification file | 1/3 | 29 fields |
-| C6 | `sec:m-recovery` says the judge cannot recover failed extractions "at a useful rate" with no number in the body. The figure exists (23 of 441, 5.2%) — print it or cut the sentence to "failed extractions are corpus loss" | 2/3 | no number in body |
-| C7 | "One call per document" vs a client that retries up to three times — distinguish logical requests from API attempts | 1/3 | `max_retries=3` in Methods |
-| C8 | The release's defect status is undocumented: the judge found 108 referential-integrity findings, 42 orphans and 56 duplicate pairs, and no repaired graph was rebuilt. State whether the released dump carries them | 2/3 | consistent with `app:judge` |
+| C2 **DONE** | "schema-constrained" (×4, incl. abstract and Fig. 1 caption) while `sec:m-extraction` concedes conformance is prompt-enforced with no structured-output constraint. Use "schema-prompted" | 1/3 | 4 occurrences, contradiction confirmed |
+| C3 **DONE** | `sec:m-repro` "a re-run reproduces the same model generation" (L627) reads against `sec:m-extraction` "runs are not bit-reproducible" (L339). Both render; the first invites the wrong reading | 1/3 | both lines confirmed |
+| C4 **DONE** (now "as run") | `tab:gates` marks the maturity-$\geq 3$ row "(deployed)" while the rubric reserves *deployed* for maturity 4. The intent is "the deployed setting"; relabel so it cannot be read as the maturity band | 1/3 | confirmed |
+| C5 **DONE** (25 moved to `paper/refs_verification_notes.md`) | `refs.bib` carries 29 non-standard annotation fields, including "Verified 2026-08-15" and per-entry mini-summaries. Move to a source-verification file | 1/3 | 29 fields |
+| C6 **DONE** (23 of 441, 5.2% now printed) | `sec:m-recovery` says the judge cannot recover failed extractions "at a useful rate" with no number in the body. The figure exists (23 of 441, 5.2%) — print it or cut the sentence to "failed extractions are corpus loss" | 2/3 | no number in body |
+| C7 **DONE** | "One call per document" vs a client that retries up to three times — distinguish logical requests from API attempts | 1/3 | `max_retries=3` in Methods |
+| C8 **DONE** (PR #159: 0 orphans / 0 dangling / 0 self-loops / 1 duplicate edge; the judge's classes were pre-ingest and do not reach the dump) | The release's defect status is undocumented: the judge found 108 referential-integrity findings, 42 orphans and 56 duplicate pairs, and no repaired graph was rebuilt. State whether the released dump carries them | 2/3 | consistent with `app:judge` |
 
 ## Language, register and typography — the low-hanging fruit
 
@@ -312,20 +327,34 @@ None of this requires a decision; all of it is a prose pass.
 
 | # | Item | Agreement | Action |
 |---|---|---|---|
-| L1 | **`\author{Author List Placeholder}` (L102) renders on page 1** — a *ninth* visible placeholder, separate from the eight `\OPEN{}` blocks of C1 | 1/3 | goes with G15; until then it is the first thing a reviewer sees |
-| L2 | **Aphoristic paragraph-enders.** "We add the layer under it."; "A corpus of $N$ short chains is exactly $N$ components until something links them."; "A faithful extraction from a weak paper is a successful extraction."; "The objective above is what the step is for; the counts below are what this approximation to it produced."; "The counts require no control, being direct tallies." | **3/3** | the internal reviews counted eight and said keep two. Opus: "deployed forty times they read as generated polish and displace information" |
-| L3 | **Contrastive correction** — "X is not Y", "read this as A and never as B". ~30 instances by the internal count, "well over a dozen" by Opus's | **3/3** | keep where a plausible misreading exists *and* the paper has evidence about it; target under 8 |
-| L4 | **"honest" as editorial** — "the honest statement of yield", "the honest positive residue" | 2/3 | GPT-5.6 Sol: "implicitly characterizes alternative summaries as dishonest" |
-| L5 | **Promotional / advocacy** — "The corpus is a snapshot of one dataset and will date. The paired extract-and-verify design will not."; "would make research coordination ... tractable"; "the natural agentic use"; "The extension this work most needs"; "What makes a mechanism layer worth building" | 2/3 | "will not [date]" is unsupported and absolute — models, prompts and schemas date too. "tractable" → "could support" |
-| L6 | **Conversational / blog register** — "What the release contains. Five things:"; "A closing note: some statistics are true by design."; "All three duly record an improvement"; "the reader who takes the release and does something with it" | 2/3 | "duly" reads as sarcasm |
-| L7 | **Legalistic meta-formulations** — "what licenses reading the other rows"; "which is what settles it"; "A reader would otherwise misread a number" | 1/3 | state the assumption and its implication directly |
-| L8 | **Formulaic openers** — "Three things follow"; "Two properties bear on"; "What this does not show" | 1/3 | frequency is the tell, not any single instance |
-| L9 | **Over-attribution of importance** (the flag Martin asked reviewers for) — "The verification stage is half the contribution" (`app:judgeprompt`); "what makes the extraction checkable rather than merely large" (`sec:r-judge`); "This is the single licensing gate"; "That qualifier is essential" (`sec:r-corpus`); "The single most consequential row is the sixth" (`tab:populations-master` caption); "the choice of extractor moves the bill by about a factor of five — more than any other decision in the pipeline" (`sec:m-repro`); "The sharpest is a merge-manufactured centrality hub at 90x" (Conclusion); "218 of 218 numeric claims passing" as a quality badge; "fifty documents ... would settle it"; the two worked queries as "the precondition for the cross-paper analysis" | **3/3** | the verification-stage claims are the load-bearing ones: the stage ran on 0.85% of documents and 0.6% of the analysed chains. The 90x hub in the Conclusion is an artifact of a step **not applied** to the released substrate, elevated to a headline |
-| L10 | **Same three caveats repeated across 6–8 sections** (verified ≠ analysed; yield is a gate property; completeness is schema-filling) | 2/3 | one clear statement each plus cross-references |
-| L11 | **Acknowledgments carry project-management detail** (Discord stand-ups, working threads) | 1/3 | not scholarly acknowledgment |
-| L12 | **Terminology overstates the evidence** — "verification", "implied coverage", documents "argue a complete mechanism" | 1/3 | → "the extractor produced a chain judged to pass the model-assigned gates"; "auditable" or "subject to an LLM diagnostic pass" rather than "verified" |
-| L13 | **Mechanical sweeps** (from the internal reviews, not re-raised externally): mixed British/American spelling — "randomisation", "neighbourhood", "specialised", "favourable" against "normalization", "labeling", "colored"; number-words inconsistent — "Twelve of the 100" vs "12 of the 100"; `\emph{}` 40+ times, mostly on ordinary words | internal | one spelling variety, one number rule, `\emph{}` for term introductions only |
-| L14 | **Source-file editorial trail** — "REMOVED 2026-08-14", "Moved out of sec:r-hub", "the frozen Overleaf reported...", "the module docstring says 80%, the code uses 70%", the compute-donor gate block. Several disclose internal disagreement, an Overleaf workflow and a private donor | internal | strip or move to a NOTES file before any public posting. **Not** the same as C1: these are comments and never render |
+| L1 (team, G15) | **`\author{Author List Placeholder}` (L102) renders on page 1** — a *ninth* visible placeholder, separate from the eight `\OPEN{}` blocks of C1 | 1/3 | goes with G15; until then it is the first thing a reviewer sees |
+| L2 **DONE** | **Aphoristic paragraph-enders.** "We add the layer under it."; "A corpus of $N$ short chains is exactly $N$ components until something links them."; "A faithful extraction from a weak paper is a successful extraction."; "The objective above is what the step is for; the counts below are what this approximation to it produced."; "The counts require no control, being direct tallies." | **3/3** | the internal reviews counted eight and said keep two. Opus: "deployed forty times they read as generated polish and displace information" |
+| L3 **PARTIAL** | **Contrastive correction** — "X is not Y", "read this as A and never as B". ~30 instances by the internal count, "well over a dozen" by Opus's | **3/3** | keep where a plausible misreading exists *and* the paper has evidence about it; target under 8 |
+| L4 **DONE** | **"honest" as editorial** — "the honest statement of yield", "the honest positive residue" | 2/3 | GPT-5.6 Sol: "implicitly characterizes alternative summaries as dishonest" |
+| L5 **DONE** | **Promotional / advocacy** — "The corpus is a snapshot of one dataset and will date. The paired extract-and-verify design will not."; "would make research coordination ... tractable"; "the natural agentic use"; "The extension this work most needs"; "What makes a mechanism layer worth building" | 2/3 | "will not [date]" is unsupported and absolute — models, prompts and schemas date too. "tractable" → "could support" |
+| L6 **DONE** | **Conversational / blog register** — "What the release contains. Five things:"; "A closing note: some statistics are true by design."; "All three duly record an improvement"; "the reader who takes the release and does something with it" | 2/3 | "duly" reads as sarcasm |
+| L7 **PARTIAL** | **Legalistic meta-formulations** — "what licenses reading the other rows"; "which is what settles it"; "A reader would otherwise misread a number" | 1/3 | state the assumption and its implication directly |
+| L8 **not done** | **Formulaic openers** — "Three things follow"; "Two properties bear on"; "What this does not show" | 1/3 | frequency is the tell, not any single instance |
+| L9 **DONE** | **Over-attribution of importance** (the flag Martin asked reviewers for) — "The verification stage is half the contribution" (`app:judgeprompt`); "what makes the extraction checkable rather than merely large" (`sec:r-judge`); "This is the single licensing gate"; "That qualifier is essential" (`sec:r-corpus`); "The single most consequential row is the sixth" (`tab:populations-master` caption); "the choice of extractor moves the bill by about a factor of five — more than any other decision in the pipeline" (`sec:m-repro`); "The sharpest is a merge-manufactured centrality hub at 90x" (Conclusion); "218 of 218 numeric claims passing" as a quality badge; "fifty documents ... would settle it"; the two worked queries as "the precondition for the cross-paper analysis" | **3/3** | the verification-stage claims are the load-bearing ones: the stage ran on 0.85% of documents and 0.6% of the analysed chains. The 90x hub in the Conclusion is an artifact of a step **not applied** to the released substrate, elevated to a headline |
+| L10 **PARTIAL** | **Same three caveats repeated across 6–8 sections** (verified ≠ analysed; yield is a gate property; completeness is schema-filling) | 2/3 | one clear statement each plus cross-references |
+| L11 **DONE** | **Acknowledgments carry project-management detail** (Discord stand-ups, working threads) | 1/3 | not scholarly acknowledgment |
+| L12 **PARTIAL** | **Terminology overstates the evidence** — "verification", "implied coverage", documents "argue a complete mechanism" | 1/3 | → "the extractor produced a chain judged to pass the model-assigned gates"; "auditable" or "subject to an LLM diagnostic pass" rather than "verified" |
+| L13 **DONE** | **Mechanical sweeps** (from the internal reviews, not re-raised externally): mixed British/American spelling — "randomisation", "neighbourhood", "specialised", "favourable" against "normalization", "labeling", "colored"; number-words inconsistent — "Twelve of the 100" vs "12 of the 100"; `\emph{}` 40+ times, mostly on ordinary words | internal | one spelling variety, one number rule, `\emph{}` for term introductions only |
+| L14 **deliberately not done** | **Source-file editorial trail** — "REMOVED 2026-08-14", "Moved out of sec:r-hub", "the frozen Overleaf reported...", "the module docstring says 80%, the code uses 70%", the compute-donor gate block. Several disclose internal disagreement, an Overleaf workflow and a private donor | internal | strip or move to a NOTES file before any public posting. **Not** the same as C1: these are comments and never render |
+
+**Prose pass, 2026-08-16.** Seventeen targeted edits, listed in the manuscript's own
+source comments. Fully done: the three named aphoristic enders (L2), both "honest"-as-
+editorial instances (L4), the five promotional phrases including "will not date" (L5),
+the blog-register openers (L6), all ten over-attribution instances the reviewers named
+(L9), the Acknowledgments project-management sentence (L11), and one spelling variety
+with `\emph{}` left alone (L13). Partial: L3 contrastive corrections were reduced where
+the rewrite touched them but were not counted down to the under-8 target; L7 and L12
+were reduced at the instances the reviewers quoted, not swept; L10's repeated caveats
+are fewer after the cuts but not consolidated to one statement each. Not done: L8
+formulaic openers, and L14 **on purpose** -- the source-comment trail is what stops a
+future session re-deriving a corrected number wrongly, and it never renders. Strip it in
+one pass immediately before posting, not now.
+
 
 **Checked and clear:** GPT-5.6 Sol asked that future-dated bibliography entries be verified
 against the submission date. Checked 2026-08-15 — `refs.bib` years top out at 2025, so there
@@ -366,6 +395,16 @@ Estimated body after the 2026-08-15 pass: **~12.5–13 pages**, down from ~15–
 estimate is a character-count heuristic, not a build — **compile on Overleaf and read the
 real number before deciding what else to cut.**
 
+🔴 **The 2026-08-16 pass did not close this gate, and the arithmetic says why.** Measured on
+non-comment source lines at commit `337d033` against `06c3440`: the appendices lost **90
+lines** to the unanimous cuts, and the body **gained 17** because the three new findings
+(edge coverage, what the collapse drops, what the release ships) had to be stated. Net for
+the whole file: −73 lines, roughly −1.7% of body characters. Every cut on the list below
+that a reviewer agreed on has now been taken, so the remaining ~3 pages have to come from
+material the reviewers wanted **kept** — which makes it an author's call, not an editorial
+one. The realistic options are the four in the ordered list below, and the first is the
+only one that yields a page on its own.
+
 Where the remaining ~3 pages would have to come from, in the order I would take them:
 
 1. **The three artifact use cases** (clustering, centrality, co-occurrence) — roughly 110
@@ -389,13 +428,13 @@ load-bearing claim":
 
 | Cut | Agreement | Disposition |
 |---|---|---|
-| Pre/post repair scoring + the agreement-instrument appendix (ICC, Krippendorff, two Fleiss binnings, median split) | **3/3** | → two sentences in Limitations; delete the statistics (see S1) |
-| `sec:r-selection` race-framing non-reproduction + `app:race` (52-node classifier validation, odds-ratio table) | **3/3** | → one paragraph carrying the general control: selection-conditioned statistics are unstable under merge and threshold choices |
-| Everything quoted from the earlier internal substrate — `tab:clustering-methods`, the first four rows of `tab:dedup-thresholds`, `app:sensitivity` hop counts | **3/3** | → cut, or re-derive on the released graph. Opus additionally asks that the recurring "earlier pass on a merged 200,061-node graph with an 8.5× sparser similarity layer" thread be consolidated into one footnote |
-| `app:clusters` 40-cluster name list | 2/3 | → size range plus 3–4 examples; ship the list with the release |
-| `sec:m-recovery` + the 441-row of `tab:populations-master` | 2/3 | → one clause (see C6) |
-| Meta-grader agent-session operational detail (13 JSON shapes, folder-agent behaviour, uneven denominators) in `app:judgeprompt` | 1/3 | → cut, or re-run the graders on a fixed schema |
-| The "218 of 218 numeric claims" audit narrative | 1/3 | → mention the reproducibility scripts once; it demonstrates manuscript consistency, not empirical validity |
+| ~~Pre/post repair scoring + the agreement-instrument appendix~~ **CUT 2026-08-16** | **3/3** | done: `sec:r-judge` keeps one paragraph naming the confound and the null-repair control; ICC / ICC(2,k) / Krippendorff / two Fleiss binnings / median split all deleted, receipt still ships |
+| ~~`sec:r-selection` race-framing + `app:race` odds-ratio table~~ **CUT 2026-08-16** | **3/3** | done: three paragraphs to one, `tab:race` gone, the 2.7-5.2 OR range kept in a clause, classifier precision kept |
+| ~~Everything quoted from the earlier internal substrate~~ **CUT 2026-08-16** | **3/3** | done: `tab:clustering-methods` and `tab:dedup-thresholds` deleted, `app:sensitivity` hop counts reduced to the growth ratio. `sec:m-repro`'s carve-out now names only the merge sweep and that ratio |
+| ~~`app:clusters` 40-cluster name list~~ **CUT 2026-08-16** | 2/3 | done: size range plus four examples; the full list ships with the release, which also closed one `\OPEN{}` block |
+| `sec:m-recovery` + the 441-row of `tab:populations-master` | 2/3 | **partly done**: the number is printed (C6) rather than the section cut. Cutting to one clause is still available if the page budget needs it |
+| ~~Meta-grader agent-session operational detail~~ **CUT 2026-08-16** | 1/3 | done: the consequence for the denominators is kept, the JSON-shape counts are gone |
+| ~~The "218 of 218 numeric claims" audit narrative~~ **CUT 2026-08-16** | 1/3 | done: the body prints no count; the audit is at 235/235 and says so only in source comments and `REPRODUCE.md` |
 
 **Explicitly keep**, named by every model that raised the topic: the merge/centrality
 artifact (`sec:r-hub`), `tab:gates`, `tab:populations-master`, the source-type skew table,

--- a/paper/REPRODUCE.md
+++ b/paper/REPRODUCE.md
@@ -36,12 +36,16 @@ Drive archives. The PKLs are only needed to re-derive the receipts from scratch.
 | §Methods, Validation | judge audit, meta-grader table, Fleiss κ, error profile, 23/441 recovery | `experiment_judge_full_receipt.py` | `experiment_judge_full_report.json` |
 | **Whole draft** | **regression check of every number** | `experiment_paper_claim_audit.py` | `experiment_paper_claim_audit.json` |
 
+> 🔴 **This copy is stale and is kept for history.** The canonical claim-to-script-to-receipt
+> map is `REPRODUCE.md` in `../AISafetyIntervention_PaperA_shared`, which travels with the
+> manuscript. Read that one.
+
 ## The one command that checks everything
 
 ```bash
 cd graph_analysis
 python -u experiment_paper_claim_audit.py
-# -> 42/42 PASS, 0 FAIL
+# -> 235/235 PASS, 0 FAIL   (2026-08-16)
 ```
 
 It re-derives each claim from the **raw** path files and node PKL (not from the other receipts) and

--- a/paper/refs_verification_notes.md
+++ b/paper/refs_verification_notes.md
@@ -1,0 +1,34 @@
+# refs.bib source-verification record
+
+Moved out of `refs.bib` on 2026-08-16. These are working notes recording what was
+checked about each reference and when; they are not bibliographic data and they
+rendered in the built bibliography, which one reviewer flagged as an unfinished file.
+Keyed by cite key so a checker can put them back beside the entry.
+
+| Cite key | Verification note |
+|---|---|
+| `kirchner2022ard` | The Alignment Research Dataset (ARD); scraper maintained by StampyAI / AI Safety Info at github.com/StampyAI/alignment-research-dataset |
+| `slattery2026airisk` | Published online 2026-03-30. 1,725 risks from 74 frameworks; Causal and Domain taxonomies. MIT FutureTech |
+| `luan2018scierc` | ACL Anthology D18-1360; introduces the SciERC dataset |
+| `bach2007relation` | Literature review, Language and Statistics II |
+| `cao2024legographrag` | Accepted to VLDB 2025 |
+| `pan2024unifying` | arXiv:2306.08302 |
+| `wu2025medgraphrag` | ACL Anthology 2025.acl-long.1381 |
+| `zheng2023judging` | arXiv:2306.05685 |
+| `kaufman1990finding` | Source of the conventional silhouette-quality thresholds used in Appendix C |
+| `teufel2002summarizing` | ACL Anthology J02-4002; introduces argumentative zoning |
+| `lippi2016argumentation` | Article 10 |
+| `lauscher2018sciarg` | ACL Anthology W18-5206; the SciArg corpus |
+| `nye2018ebmnlp` | ACL Anthology P18-1019; the EBM-NLP corpus; arXiv:1806.04185 |
+| `panickssery2024selfpreference` | arXiv:2404.13076 |
+| `wang2024notfair` | ACL Anthology 2024.acl-long.511; arXiv:2305.17926 |
+| `grey2025atlas` | Edition 1; recommended citation from ai-safety-atlas.com, retrieved 2026-08-14 |
+| `stampy2023aisafetyinfo` | Question-and-answer resource founded by Rob Miles, maintained by a volunteer team under Ashgro Inc.; source of the Alignment Research Dataset. Retrieved 2026-08-15 |
+| `markov2023safetychatbot` | Published 2023-12-21. Retrieval-augmented question answering over the Alignment Research Dataset with citations to source documents; embedding retrieval over chunked text. Retrieved 2026-08-15 |
+| `mouratoglou2024aisafetygraph` | Clusters over 5,000 Alignment Research Dataset papers with an LLM and renders them as an interactive document-level network. Began at the Research Augmentation Hackathon, August 2024, per the project repository. Retrieved 2026-08-15 |
+| `buehler2024discovery` | 1,000 biological-materials papers to an ontological knowledge graph, then path-finding between distant concepts to propose designs. Verified at iopscience.iop.org 2026-08-15 |
+| `krenn2022predicting` | Link prediction over a semantic network built from 100,000+ AI papers, to forecast which concept pairs will be studied together. Verified 2026-08-15 |
+| `tong2024hypothesis` | LLM plus a causal knowledge graph over the literature to generate and rank novel hypotheses. Verified 2026-08-15 |
+| `edge2024graphrag` | Entity graph plus community summaries for query-focused summarization. Verified 2026-08-15 |
+| `skarlinski2024paperqa2` | PaperQA2: retrieval, summarization and contradiction detection over the scientific literature, evaluated against subject-matter experts. Verified 2026-08-15 |
+| `alphaxiv2026` | Author- and paper-centric navigation layer over arXiv, with researcher profiles and citation metrics. Retrieved 2026-08-15 |


### PR DESCRIPTION
Follow-on to #158 and #159, which it contains by merge. Open those two first; this one is the bookkeeping that makes the manuscript and the audit agree again.

## The audit

**14 checks removed**, each with the number it guarded, all of which left the manuscript in commit `337d033` of the shared repo:

- six grader agreement instruments (ICC(2,1), ICC(2,k), Krippendorff alpha, pre and post) — the pre/post repair-scoring stage is now one paragraph naming the confound, with no statistics
- six per-grader session diagnostics (files seen, distinct JSON shapes) — the operational detail behind the 95/95/13 denominators is cut; the denominators themselves stay in `tab:populations-master` and keep their checks
- two "implied coverage" figures (99.4% / 77.7%) — the phrasing is gone

A check for a number the paper does not print is not a regression test. Leaving them would have kept the audit green while measuring nothing.

**31 checks added** for the three studies:

| Study | Checks |
|---|---|
| edge coverage (#156) | 777 rows / 328 / 146 / 302, 3.02 per paper, 90 of 100 papers, 1,667 released edges, 16.7 per paper, 18.1%, 28.1% against the judge's own count, 10.76 judge mean, no `add_edges` slot, 0 cross-paper edges |
| containment semantics (#157) | 0.0% contiguous sub-paths, 21.7% chords-only, 78.3% touching a novel node, 28.0% ending elsewhere, 579 pairs lost, 18.0% |
| release integrity (#157) | 0 orphans, 0 dangling, 0 self-loops, 1 duplicate edge, 448 groups, 1,140 nodes, all gate attributes present, 1,617 nodes / 0.81% audited |
| recovery (C6) | 441 candidates, 23 recovered, 5.2% — now printed in `sec:m-recovery` instead of "not at a useful rate" |

Two of the new ones are assertions rather than comparisons: that the judge's repair schema still has no `add_edges` slot, and that every gate attribute is present on every node and edge that carries one. Both are claims the manuscript makes in prose about the artifact, and both would silently become false if the substrate were rebuilt differently.

`python -u experiment_paper_claim_audit.py` → **235/235 PASS, 0 FAIL**.

## Docs

- `REPRODUCE.md` (both copies): a row per new script, the audit count refreshed, and the analysis-repo copy marked stale with a pointer to the shared one, which is the file a reviewer actually runs.
- `OPEN_ITEMS.md`: marked down **in place** rather than appended to. S10 closed with its result; C2–C9 closed; every unanimous cut-list row marked executed; the fourteen language rows marked done / partial / deliberately-not-done individually rather than uniformly closed — L14 (the source-comment trail) is explicitly *not* done, because those comments are what stop a future session re-deriving a corrected number wrongly, and they never render.
- The page-budget section now carries a measurement instead of an estimate: **appendices −90 non-comment lines, body +17**, net −73 for the file. The ten-page gate is **not** closed by this pass. Every cut a reviewer agreed on has been taken, so the remaining ~3 pages have to come out of material the reviewers wanted kept — an author's call, and it needs a real Overleaf build first.
- `paper/refs_verification_notes.md` is new: the 25 per-entry `note` fields that used to render in the bibliography, preserved by cite key. They live here rather than in the shared repo because that repo's `.gitignore` keeps internal working documents out on purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)