### PR TITLE
Chain order and edge orientation: what an undirected enumerator actually produced (#173)

### DIFF
--- a/graph_analysis/experiment_paper_claim_audit.py
+++ b/graph_analysis/experiment_paper_claim_audit.py
@@ -1458,6 +1458,118 @@ def main():
     # by a reader at reasonable cost, so the claims they backed were withdrawn from
     # the manuscript. Reinstate only if that file ships with the release.
 
+    # ---- within-instrument coverage denominators (2026-08-17 external round) ----------
+    # Two reviewers objected that dividing flagged-missing relationships by released edges
+    # is not the rate the coverage list itself implies. The paper now prints both, so both
+    # are checked. The fourth status of the first run's list is what made 328+146+302 read
+    # as an arithmetic error against the stated 777.
+    cl2 = receipt("experiment_review_edge_coverage_report.json")["coverage_list"]
+    check(
+        "coverage list: fourth status row (covered abstractly)",
+        1,
+        cl2["unlabelled_or_other"],
+    )
+    check(
+        "coverage list: statuses sum to the row total",
+        777,
+        cl2["covered"]
+        + cl2["partially_covered"]
+        + cl2["missing"]
+        + cl2["unlabelled_or_other"],
+    )
+    check(
+        "coverage list: missing as a share of the list",
+        38.9,
+        round(100.0 * cl2["missing"] / cl2["rows_total"], 1),
+    )
+    cy = receipt("experiment_review_judge_chainyielding_report.json")
+    check(
+        "second judge run: coverage list rows", 627, cy["edge_level"]["coverage_rows"]
+    )
+    check(
+        "second judge run: missing as a share of its list",
+        75.9,
+        round(
+            100.0 * cy["edge_level"]["missing"] / cy["edge_level"]["coverage_rows"], 1
+        ),
+    )
+
+    # ---- chain order and edge orientation (2026-08-17, reviewers GC/GW) --------------
+    # The enumerator is undirected and imposes no monotonic stage order, so the reviewers
+    # asked what the released chains actually do. Every figure the manuscript prints for
+    # this is re-derived by experiment_review_chain_order_semantics.py from the released
+    # path files, the node table and the edge list.
+    co = receipt("experiment_review_chain_order_semantics_report.json")
+    ded_co, raw_co = co["deduped_2772"], co["raw_8954"]
+    so, ed = ded_co["stage_order"], ded_co["edge_direction"]
+    check(
+        "chain order: monotonic stage order, reporting unit", 84.6, so["monotonic_pct"]
+    )
+    check(
+        "chain order: strictly increasing, reporting unit",
+        72.0,
+        so["strictly_increasing_pct"],
+    )
+    check("chain order: chains with an inversion", 427, so["chains_with_an_inversion"])
+    check(
+        "chain order: chains inverting exactly once",
+        299,
+        so["inversions_per_chain_hist"]["1"],
+    )
+    inversion_pairs = dict(map(tuple, so["most_common_inversions_rank_pairs"]))
+    check(
+        "chain order: commonest inversion is va -> im, instances",
+        229,
+        inversion_pairs["5->4"],
+    )
+    check(
+        "chain order: monotonic on the raw set",
+        66.2,
+        raw_co["stage_order"]["monotonic_pct"],
+    )
+    check(
+        "edge orientation: chains with every hop stored forward",
+        80.6,
+        ed["chains_all_hops_forward_pct"],
+    )
+    check("edge orientation: hops in the reporting unit", 17829, ded_co["n_hops"])
+    check("edge orientation: hops walked backward", 800, ed["hops_backward"])
+    check("edge orientation: hops walked backward, pct", 4.5, ed["hops_backward_pct"])
+    check(
+        "edge orientation: backward hops against their type's majority",
+        799,
+        ed["hops_against_type_majority_orientation"],
+    )
+    check(
+        "edge orientation: all-forward chains on the raw set",
+        62.7,
+        raw_co["edge_direction"]["chains_all_hops_forward_pct"],
+    )
+    check(
+        "edge orientation: backward hops on the raw set, pct",
+        7.9,
+        raw_co["edge_direction"]["hops_backward_pct"],
+    )
+    check(
+        "edge orientation: no hop unresolved in either direction",
+        0,
+        ed["unresolved_hops"],
+    )
+    # The 98.9-99.7 band the manuscript quotes covers exactly the five relation types with
+    # more than 25,000 instances. Checked as a band so a future re-run cannot widen it
+    # silently to include enabled_by (90.8) or required_by (80.0).
+    orient = co["relation_type_orientation_over_the_whole_graph"]
+    big = {k: v for k, v in orient.items() if v["up"] + v["down"] > 25_000}
+    shares = sorted(v["majority_share_pct"] for v in big.values())
+    check("orientation band: number of types over 25,000 instances", 5, len(big))
+    check(
+        "orientation band: every one of them ascends the stage rank",
+        True,
+        all(v["majority"] == "up" for v in big.values()),
+    )
+    check("orientation band: low end", 98.9, shares[0])
+    check("orientation band: high end", 99.7, shares[-1])
+
     out = {
         "audit": "paperA_draft_v2.tex quantitative claims vs raw data",
         "n_claims_checked": len(results),

--- a/graph_analysis/experiment_review_chain_order_semantics.py
+++ b/graph_analysis/experiment_review_chain_order_semantics.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""Do the released chains obey the stage order they are described in, and are their
+edges walked with or against the orientation the extractor stored?
+
+Answers the 2026-08-17 external-review objection (reviewers GC and GW, both bars):
+the enumerator traverses edges undirected and the constraint list in app:cuts does NOT
+require the concept categories to progress monotonically along the canonical chain, so a
+"risk-to-intervention mechanism chain" might be a connected node sequence rather than a
+directed argument. Nothing in the manuscript answers that today.
+
+Class B: no LLM call, no network. Reads the released path files, the slim node attribute
+table and the structural edge list, and writes one receipt.
+
+Definitions, all reported separately because they answer different questions:
+
+  monotonic (non-decreasing)  the stage rank never decreases along the chain. Repeats of
+                              one stage are allowed, which the schema explicitly permits.
+  strictly ordered            no repeats either: rank increases at every hop.
+  inversions                  hops where the rank decreases, counted and located.
+  forward hop                 a structural edge exists in the stored orientation
+                              source -> target matching the traversal direction.
+  backward hop                the edge exists only as target -> source, i.e. the
+                              traversal walks it against the orientation the extractor
+                              wrote.
+  against-majority hop        a backward hop whose relation type, measured over the whole
+                              graph, predominantly runs from lower to higher stage rank.
+                              This is the data-derived version of the reviewers' "after
+                              canonicalizing relation direction" request; no orientation is
+                              assumed a priori.
+
+Usage
+-----
+    cd graph_analysis
+    python -u experiment_review_chain_order_semantics.py
+"""
+
+from __future__ import annotations
+
+import json
+import pickle
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+PATHS_RAW = HERE / "phase1_rawpathsfiles" / "paths_hopwise_v4_edge_only.jsonl"
+PATHS_DEDUPED = (
+    HERE / "phase1_rawpathsfiles" / "paths_hopwise_v4_edge_only_deduped.jsonl"
+)
+NODE_ATTRS = HERE / "phase2_results" / "node_attrs_slim.pkl"
+EDGE_DATA = (
+    HERE
+    / "phase2_results"
+    / "step1_load_and_parse_umapwithoutlocalsatellites"
+    / "graph_edge_data.pkl"
+)
+OUT = HERE / "phase2_results" / "experiment_review_chain_order_semantics_report.json"
+
+# The logical chain, in the order CLAUDE.md fixes and the paper never reorders.
+STAGE_RANK = {
+    "risk": 0,
+    "problem analysis": 1,
+    "theoretical insight": 2,
+    "design rationale": 3,
+    "implementation mechanism": 4,
+    "validation evidence": 5,
+}
+INTERVENTION_RANK = 6
+
+
+def die(what: str, expected: Path, produced_by: str) -> None:
+    raise SystemExit(
+        f"FATAL: {what} not found.\n"
+        f"  expected: {expected}\n"
+        f"  produced by: {produced_by}\n"
+        f"  This script does NOT rebuild it and does NOT fall back to another source. It\n"
+        f"  measures the RELEASED chain set only; there is no substitute input."
+    )
+
+
+def load_paths(path: Path) -> list[list[int]]:
+    if not path.is_file():
+        die("path file", path, "phase2_step4_F2v4_hopwise_falkordb.py")
+    out: list[list[int]] = []
+    with path.open(encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            rec = json.loads(line)
+            # The released files key the node sequence as "path"; "nodes" is accepted only
+            # so a hand-made fixture does not need re-keying.
+            if isinstance(rec, dict):
+                nodes = rec.get("path") or rec.get("nodes")
+            else:
+                nodes = rec
+            if not isinstance(nodes, list) or not nodes:
+                raise SystemExit(
+                    f"FATAL: {path.name} carries a record with no node list: {rec!r:.200}"
+                )
+            out.append([int(n) for n in nodes])
+    return out
+
+
+def rank_of(node_id: int, attrs: dict) -> int | None:
+    a = attrs.get(node_id)
+    if a is None:
+        return None
+    if a.get("type") == "intervention":
+        return INTERVENTION_RANK
+    return STAGE_RANK.get(a.get("concept_category"))
+
+
+def analyse(
+    paths: list[list[int]],
+    attrs: dict,
+    fwd: dict,
+    rev: dict,
+    majority: dict[str, str] | None = None,
+) -> dict:
+    n = len(paths)
+    monotonic = strict = 0
+    all_forward = any_backward = 0
+    unresolved_hops = 0
+    hops_total = hops_backward = 0
+    inversion_pairs: Counter = Counter()
+    backward_types: Counter = Counter()
+    forward_types: Counter = Counter()
+    inversions_per_chain: Counter = Counter()
+    backward_per_chain: Counter = Counter()
+    unranked_nodes = 0
+    against_majority = 0
+    majority = majority or {}
+
+    for nodes in paths:
+        ranks = [rank_of(x, attrs) for x in nodes]
+        unranked_nodes += sum(1 for r in ranks if r is None)
+        known = [r for r in ranks if r is not None]
+        inv = 0
+        for a, b in zip(known, known[1:]):
+            if b < a:
+                inv += 1
+                inversion_pairs[f"{a}->{b}"] += 1
+        inversions_per_chain[inv] += 1
+        if inv == 0:
+            monotonic += 1
+            if all(b > a for a, b in zip(known, known[1:])):
+                strict += 1
+
+        back = 0
+        for u, v in zip(nodes, nodes[1:]):
+            hops_total += 1
+            f = fwd.get((u, v))
+            r = rev.get((u, v))
+            if f is not None:
+                forward_types[f] += 1
+            elif r is not None:
+                back += 1
+                hops_backward += 1
+                backward_types[r] += 1
+                # A backward hop matters most where the relation type is otherwise
+                # consistent: if the type predominantly ascends the stage rank across the
+                # whole graph, walking one instance of it backward is a traversal against
+                # the orientation the extractor itself uses for that type.
+                if majority.get(r) == "up":
+                    against_majority += 1
+            else:
+                unresolved_hops += 1
+        backward_per_chain[back] += 1
+        if back == 0:
+            all_forward += 1
+        else:
+            any_backward += 1
+
+    return {
+        "n_chains": n,
+        "n_hops": hops_total,
+        "stage_order": {
+            "monotonic_non_decreasing": monotonic,
+            "monotonic_pct": round(100.0 * monotonic / n, 1) if n else None,
+            "strictly_increasing": strict,
+            "strictly_increasing_pct": round(100.0 * strict / n, 1) if n else None,
+            "chains_with_an_inversion": n - monotonic,
+            "chains_with_an_inversion_pct": (
+                round(100.0 * (n - monotonic) / n, 1) if n else None
+            ),
+            "inversions_per_chain_hist": dict(sorted(inversions_per_chain.items())),
+            "most_common_inversions_rank_pairs": inversion_pairs.most_common(10),
+        },
+        "edge_direction": {
+            "chains_all_hops_forward": all_forward,
+            "chains_all_hops_forward_pct": (
+                round(100.0 * all_forward / n, 1) if n else None
+            ),
+            "chains_with_a_backward_hop": any_backward,
+            "chains_with_a_backward_hop_pct": (
+                round(100.0 * any_backward / n, 1) if n else None
+            ),
+            "hops_backward": hops_backward,
+            "hops_backward_pct": (
+                round(100.0 * hops_backward / hops_total, 1) if hops_total else None
+            ),
+            "backward_hops_per_chain_hist": dict(sorted(backward_per_chain.items())),
+            "relation_types_walked_forward": forward_types.most_common(),
+            "relation_types_walked_backward": backward_types.most_common(),
+            "hops_against_type_majority_orientation": against_majority,
+            "hops_against_type_majority_orientation_pct": (
+                round(100.0 * against_majority / hops_total, 1) if hops_total else None
+            ),
+            "unresolved_hops": unresolved_hops,
+        },
+        "unranked_nodes_encountered": unranked_nodes,
+    }
+
+
+def main() -> int:
+    if not NODE_ATTRS.is_file():
+        die("slim node attributes", NODE_ATTRS, "experiment_review_prep_slim_nodes.py")
+    if not EDGE_DATA.is_file():
+        die("structural edge list", EDGE_DATA, "phase2_step1_loadandparse.py")
+
+    print("loading node attributes ...", flush=True)
+    attrs = pickle.load(NODE_ATTRS.open("rb"))
+    print(f"  {len(attrs):,} nodes", flush=True)
+
+    print("loading edges ...", flush=True)
+    edges = pickle.load(EDGE_DATA.open("rb"))
+    fwd: dict[tuple[int, int], str] = {}
+    rev: dict[tuple[int, int], str] = {}
+    type_orientation: dict[str, Counter] = defaultdict(Counter)
+    n_struct = 0
+    for e in edges:
+        if e.get("type") != "EDGE":
+            continue
+        n_struct += 1
+        s, t = int(e["source"]), int(e["target"])
+        sub = e.get("subtype") or "unknown"
+        fwd.setdefault((s, t), sub)
+        rev.setdefault((t, s), sub)
+        rs, rt = rank_of(s, attrs), rank_of(t, attrs)
+        if rs is not None and rt is not None and rs != rt:
+            type_orientation[sub]["up" if rt > rs else "down"] += 1
+    print(f"  {n_struct:,} structural edges", flush=True)
+
+    majority_up = {
+        k: {
+            "up": v["up"],
+            "down": v["down"],
+            "majority": "up" if v["up"] >= v["down"] else "down",
+            "majority_share_pct": round(
+                100.0 * max(v["up"], v["down"]) / (v["up"] + v["down"]), 1
+            ),
+        }
+        for k, v in sorted(type_orientation.items())
+    }
+
+    report = {
+        "study": "chain order and edge orientation of the released chain set",
+        "answers": (
+            "2026-08-17 external review, reviewers GC and GW: the enumerator is undirected "
+            "and app:cuts imposes no monotonic stage-order constraint, so 'chain' may "
+            "describe a connected node sequence rather than a directed argument."
+        ),
+        "inputs": {
+            "raw_paths": str(PATHS_RAW.name),
+            "deduped_paths": str(PATHS_DEDUPED.name),
+            "node_attrs": str(NODE_ATTRS.name),
+            "edges": str(EDGE_DATA.name),
+            "n_structural_edges": n_struct,
+        },
+        "relation_type_orientation_over_the_whole_graph": majority_up,
+    }
+
+    for label, path in (("deduped_2772", PATHS_DEDUPED), ("raw_8954", PATHS_RAW)):
+        print(f"analysing {label} ...", flush=True)
+        paths = load_paths(path)
+        report[label] = analyse(
+            paths, attrs, fwd, rev, {k: v["majority"] for k, v in majority_up.items()}
+        )
+        s = report[label]["stage_order"]
+        d = report[label]["edge_direction"]
+        print(
+            f"  {report[label]['n_chains']:,} chains | monotonic "
+            f"{s['monotonic_pct']}% | all hops forward {d['chains_all_hops_forward_pct']}%"
+            f" | backward hops {d['hops_backward_pct']}%",
+            flush=True,
+        )
+
+    OUT.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    print(f"\nwrote {OUT}", flush=True)
+
+    d = report["deduped_2772"]
+    print("\n=== headline, reporting unit (2,772 chains) ===")
+    print(f"  monotonic stage order      : {d['stage_order']['monotonic_pct']}%")
+    print(
+        f"  strictly increasing        : {d['stage_order']['strictly_increasing_pct']}%"
+    )
+    print(
+        f"  chains with every hop stored forward: "
+        f"{d['edge_direction']['chains_all_hops_forward_pct']}%"
+    )
+    print(f"  hops walked backward       : {d['edge_direction']['hops_backward_pct']}%")
+    if d["edge_direction"]["unresolved_hops"]:
+        print(
+            f"  WARNING unresolved hops    : {d['edge_direction']['unresolved_hops']}"
+            " (no structural edge found in either orientation)"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/graph_analysis/experiment_review_containment_semantics.py
+++ b/graph_analysis/experiment_review_containment_semantics.py
@@ -116,10 +116,18 @@ def main():
     }
 
     edges = pickle.load(open(EDGES, "rb"))
-    # Hop-wise enumeration walks structural edges without regard to direction: 94.1% of the
-    # hops in the released path file match an edge (source -> target) and 100% match one
-    # (source, target) unordered, so pairs are keyed unordered here. Keying them directed
-    # would report every reversed hop as an edge the graph does not contain.
+    # Hop-wise enumeration walks structural edges without regard to direction: 100% of the
+    # hops in both released path files match an edge as an unordered (source, target) pair,
+    # so pairs are keyed unordered here. Keying them directed would report every reversed hop
+    # as an edge the graph does not contain.
+    # CORRECTED 2026-08-17. This comment used to say 94.1% of hops match a DIRECTED
+    # source -> target edge. That figure is not reproducible and must not be cited -- it also
+    # reached the body of GitHub issue #157. experiment_review_chain_order_semantics.py
+    # measures the quantity properly and the manuscript now quotes it at instance level:
+    # 92.1% of the raw set's 62,923 hops and 95.5% of the reporting unit's 17,829 are stored
+    # in the direction the chain walks them. The nearest figure to 94.1% is 94.6%, which is
+    # the same measure over DISTINCT hop pairs of the raw file rather than hop instances;
+    # if that is what 94.1% was, it was measuring pairs and reporting them as hops.
     subtypes_of_pair = defaultdict(set)
     for e in edges:
         if e.get("type") != "EDGE":

--- a/graph_analysis/phase2_results/experiment_paper_claim_audit.json
+++ b/graph_analysis/phase2_results/experiment_paper_claim_audit.json
@@ -1,7 +1,7 @@
 {
  "audit": "paperA_draft_v2.tex quantitative claims vs raw data",
- "n_claims_checked": 355,
- "n_pass": 355,
+ "n_claims_checked": 378,
+ "n_pass": 378,
  "n_fail": 0,
  "claims": [
   {
@@ -2524,6 +2524,167 @@
    "claim": "single-path risks in the EC top-100",
    "in_draft": 38,
    "recomputed_from_raw": 38,
+   "verdict": "PASS",
+   "note": ""
+  },
+  {
+   "claim": "coverage list: fourth status row (covered abstractly)",
+   "in_draft": 1,
+   "recomputed_from_raw": 1,
+   "verdict": "PASS",
+   "note": ""
+  },
+  {
+   "claim": "coverage list: statuses sum to the row total",
+   "in_draft": 777,
+   "recomputed_from_raw": 777,
+   "verdict": "PASS",
+   "note": ""
+  },
+  {
+   "claim": "coverage list: missing as a share of the list",
+   "in_draft": 38.9,
+   "recomputed_from_raw": 38.9,
+   "verdict": "PASS",
+   "note": ""
+  },
+  {
+   "claim": "second judge run: coverage list rows",
+   "in_draft": 627,
+   "recomputed_from_raw": 627,
+   "verdict": "PASS",
+   "note": ""
+  },
+  {
+   "claim": "second judge run: missing as a share of its list",
+   "in_draft": 75.9,
+   "recomputed_from_raw": 75.9,
+   "verdict": "PASS",
+   "note": ""
+  },
+  {
+   "claim": "chain order: monotonic stage order, reporting unit",
+   "in_draft": 84.6,
+   "recomputed_from_raw": 84.6,
+   "verdict": "PASS",
+   "note": ""
+  },
+  {
+   "claim": "chain order: strictly increasing, reporting unit",
+   "in_draft": 72.0,
+   "recomputed_from_raw": 72.0,
+   "verdict": "PASS",
+   "note": ""
+  },
+  {
+   "claim": "chain order: chains with an inversion",
+   "in_draft": 427,
+   "recomputed_from_raw": 427,
+   "verdict": "PASS",
+   "note": ""
+  },
+  {
+   "claim": "chain order: chains inverting exactly once",
+   "in_draft": 299,
+   "recomputed_from_raw": 299,
+   "verdict": "PASS",
+   "note": ""
+  },
+  {
+   "claim": "chain order: commonest inversion is va -> im, instances",
+   "in_draft": 229,
+   "recomputed_from_raw": 229,
+   "verdict": "PASS",
+   "note": ""
+  },
+  {
+   "claim": "chain order: monotonic on the raw set",
+   "in_draft": 66.2,
+   "recomputed_from_raw": 66.2,
+   "verdict": "PASS",
+   "note": ""
+  },
+  {
+   "claim": "edge orientation: chains with every hop stored forward",
+   "in_draft": 80.6,
+   "recomputed_from_raw": 80.6,
+   "verdict": "PASS",
+   "note": ""
+  },
+  {
+   "claim": "edge orientation: hops in the reporting unit",
+   "in_draft": 17829,
+   "recomputed_from_raw": 17829,
+   "verdict": "PASS",
+   "note": ""
+  },
+  {
+   "claim": "edge orientation: hops walked backward",
+   "in_draft": 800,
+   "recomputed_from_raw": 800,
+   "verdict": "PASS",
+   "note": ""
+  },
+  {
+   "claim": "edge orientation: hops walked backward, pct",
+   "in_draft": 4.5,
+   "recomputed_from_raw": 4.5,
+   "verdict": "PASS",
+   "note": ""
+  },
+  {
+   "claim": "edge orientation: backward hops against their type's majority",
+   "in_draft": 799,
+   "recomputed_from_raw": 799,
+   "verdict": "PASS",
+   "note": ""
+  },
+  {
+   "claim": "edge orientation: all-forward chains on the raw set",
+   "in_draft": 62.7,
+   "recomputed_from_raw": 62.7,
+   "verdict": "PASS",
+   "note": ""
+  },
+  {
+   "claim": "edge orientation: backward hops on the raw set, pct",
+   "in_draft": 7.9,
+   "recomputed_from_raw": 7.9,
+   "verdict": "PASS",
+   "note": ""
+  },
+  {
+   "claim": "edge orientation: no hop unresolved in either direction",
+   "in_draft": 0,
+   "recomputed_from_raw": 0,
+   "verdict": "PASS",
+   "note": ""
+  },
+  {
+   "claim": "orientation band: number of types over 25,000 instances",
+   "in_draft": 5,
+   "recomputed_from_raw": 5,
+   "verdict": "PASS",
+   "note": ""
+  },
+  {
+   "claim": "orientation band: every one of them ascends the stage rank",
+   "in_draft": true,
+   "recomputed_from_raw": true,
+   "verdict": "PASS",
+   "note": ""
+  },
+  {
+   "claim": "orientation band: low end",
+   "in_draft": 98.9,
+   "recomputed_from_raw": 98.9,
+   "verdict": "PASS",
+   "note": ""
+  },
+  {
+   "claim": "orientation band: high end",
+   "in_draft": 99.7,
+   "recomputed_from_raw": 99.7,
    "verdict": "PASS",
    "note": ""
   }

--- a/graph_analysis/phase2_results/experiment_review_chain_order_semantics_report.json
+++ b/graph_analysis/phase2_results/experiment_review_chain_order_semantics_report.json
@@ -1,0 +1,599 @@
+{
+  "study": "chain order and edge orientation of the released chain set",
+  "answers": "2026-08-17 external review, reviewers GC and GW: the enumerator is undirected and app:cuts imposes no monotonic stage-order constraint, so 'chain' may describe a connected node sequence rather than a directed argument.",
+  "inputs": {
+    "raw_paths": "paths_hopwise_v4_edge_only.jsonl",
+    "deduped_paths": "paths_hopwise_v4_edge_only_deduped.jsonl",
+    "node_attrs": "node_attrs_slim.pkl",
+    "edges": "graph_edge_data.pkl",
+    "n_structural_edges": 202149
+  },
+  "relation_type_orientation_over_the_whole_graph": {
+    "addressed_by": {
+      "up": 5645,
+      "down": 39,
+      "majority": "up",
+      "majority_share_pct": 99.3
+    },
+    "addresses": {
+      "up": 2,
+      "down": 11,
+      "majority": "down",
+      "majority_share_pct": 84.6
+    },
+    "caused_by": {
+      "up": 32024,
+      "down": 360,
+      "majority": "up",
+      "majority_share_pct": 98.9
+    },
+    "causes": {
+      "up": 2,
+      "down": 0,
+      "majority": "up",
+      "majority_share_pct": 100.0
+    },
+    "contributed_by": {
+      "up": 1,
+      "down": 0,
+      "majority": "up",
+      "majority_share_pct": 100.0
+    },
+    "design rationale": {
+      "up": 4,
+      "down": 0,
+      "majority": "up",
+      "majority_share_pct": 100.0
+    },
+    "design_rationale": {
+      "up": 3,
+      "down": 0,
+      "majority": "up",
+      "majority_share_pct": 100.0
+    },
+    "design_rationale_for": {
+      "up": 3,
+      "down": 0,
+      "majority": "up",
+      "majority_share_pct": 100.0
+    },
+    "enabled_by": {
+      "up": 7824,
+      "down": 789,
+      "majority": "up",
+      "majority_share_pct": 90.8
+    },
+    "enables": {
+      "up": 502,
+      "down": 2,
+      "majority": "up",
+      "majority_share_pct": 99.6
+    },
+    "exacerbated_by": {
+      "up": 12,
+      "down": 0,
+      "majority": "up",
+      "majority_share_pct": 100.0
+    },
+    "explained_by": {
+      "up": 19,
+      "down": 0,
+      "majority": "up",
+      "majority_share_pct": 100.0
+    },
+    "guides": {
+      "up": 2,
+      "down": 0,
+      "majority": "up",
+      "majority_share_pct": 100.0
+    },
+    "implementation_by": {
+      "up": 1,
+      "down": 0,
+      "majority": "up",
+      "majority_share_pct": 100.0
+    },
+    "implemented_by": {
+      "up": 38525,
+      "down": 232,
+      "majority": "up",
+      "majority_share_pct": 99.4
+    },
+    "mitigated_by": {
+      "up": 28108,
+      "down": 90,
+      "majority": "up",
+      "majority_share_pct": 99.7
+    },
+    "mitigates": {
+      "up": 0,
+      "down": 9,
+      "majority": "down",
+      "majority_share_pct": 100.0
+    },
+    "motivated_by": {
+      "up": 16,
+      "down": 6,
+      "majority": "up",
+      "majority_share_pct": 72.7
+    },
+    "motivates": {
+      "up": 40111,
+      "down": 153,
+      "majority": "up",
+      "majority_share_pct": 99.6
+    },
+    "motives": {
+      "up": 3,
+      "down": 0,
+      "majority": "up",
+      "majority_share_pct": 100.0
+    },
+    "preceded_by": {
+      "up": 45,
+      "down": 15,
+      "majority": "up",
+      "majority_share_pct": 75.0
+    },
+    "refined_by": {
+      "up": 2030,
+      "down": 49,
+      "majority": "up",
+      "majority_share_pct": 97.6
+    },
+    "related_to": {
+      "up": 3,
+      "down": 0,
+      "majority": "up",
+      "majority_share_pct": 100.0
+    },
+    "required_by": {
+      "up": 654,
+      "down": 164,
+      "majority": "up",
+      "majority_share_pct": 80.0
+    },
+    "specified_by": {
+      "up": 1195,
+      "down": 108,
+      "majority": "up",
+      "majority_share_pct": 91.7
+    },
+    "supported_by": {
+      "up": 3,
+      "down": 0,
+      "majority": "up",
+      "majority_share_pct": 100.0
+    },
+    "supports": {
+      "up": 1,
+      "down": 0,
+      "majority": "up",
+      "majority_share_pct": 100.0
+    },
+    "validated_by": {
+      "up": 35706,
+      "down": 160,
+      "majority": "up",
+      "majority_share_pct": 99.6
+    },
+    "validates": {
+      "up": 1,
+      "down": 3,
+      "majority": "down",
+      "majority_share_pct": 75.0
+    }
+  },
+  "deduped_2772": {
+    "n_chains": 2772,
+    "n_hops": 17829,
+    "stage_order": {
+      "monotonic_non_decreasing": 2345,
+      "monotonic_pct": 84.6,
+      "strictly_increasing": 1996,
+      "strictly_increasing_pct": 72.0,
+      "chains_with_an_inversion": 427,
+      "chains_with_an_inversion_pct": 15.4,
+      "inversions_per_chain_hist": {
+        "0": 2345,
+        "1": 299,
+        "2": 85,
+        "3": 27,
+        "4": 14,
+        "5": 2
+      },
+      "most_common_inversions_rank_pairs": [
+        [
+          "5->4",
+          229
+        ],
+        [
+          "4->3",
+          108
+        ],
+        [
+          "3->2",
+          80
+        ],
+        [
+          "6->5",
+          77
+        ],
+        [
+          "2->1",
+          76
+        ],
+        [
+          "5->3",
+          12
+        ],
+        [
+          "3->1",
+          8
+        ],
+        [
+          "6->4",
+          7
+        ],
+        [
+          "5->2",
+          6
+        ],
+        [
+          "4->2",
+          5
+        ]
+      ]
+    },
+    "edge_direction": {
+      "chains_all_hops_forward": 2235,
+      "chains_all_hops_forward_pct": 80.6,
+      "chains_with_a_backward_hop": 537,
+      "chains_with_a_backward_hop_pct": 19.4,
+      "hops_backward": 800,
+      "hops_backward_pct": 4.5,
+      "backward_hops_per_chain_hist": {
+        "0": 2235,
+        "1": 372,
+        "2": 105,
+        "3": 35,
+        "4": 17,
+        "5": 5,
+        "6": 2,
+        "8": 1
+      },
+      "relation_types_walked_forward": [
+        [
+          "implemented_by",
+          3334
+        ],
+        [
+          "caused_by",
+          3152
+        ],
+        [
+          "validated_by",
+          2936
+        ],
+        [
+          "motivates",
+          2860
+        ],
+        [
+          "mitigated_by",
+          2772
+        ],
+        [
+          "enabled_by",
+          889
+        ],
+        [
+          "addressed_by",
+          516
+        ],
+        [
+          "refined_by",
+          339
+        ],
+        [
+          "specified_by",
+          126
+        ],
+        [
+          "required_by",
+          58
+        ],
+        [
+          "enables",
+          42
+        ],
+        [
+          "design rationale",
+          1
+        ],
+        [
+          "extended_by",
+          1
+        ],
+        [
+          "motivated_by",
+          1
+        ],
+        [
+          "design_rationale_for",
+          1
+        ],
+        [
+          "exacerbated_by",
+          1
+        ]
+      ],
+      "relation_types_walked_backward": [
+        [
+          "validated_by",
+          250
+        ],
+        [
+          "implemented_by",
+          138
+        ],
+        [
+          "enabled_by",
+          102
+        ],
+        [
+          "mitigated_by",
+          87
+        ],
+        [
+          "motivates",
+          84
+        ],
+        [
+          "caused_by",
+          52
+        ],
+        [
+          "refined_by",
+          34
+        ],
+        [
+          "required_by",
+          20
+        ],
+        [
+          "specified_by",
+          15
+        ],
+        [
+          "addressed_by",
+          11
+        ],
+        [
+          "preceded_by",
+          4
+        ],
+        [
+          "enables",
+          2
+        ],
+        [
+          "addresses",
+          1
+        ]
+      ],
+      "hops_against_type_majority_orientation": 799,
+      "hops_against_type_majority_orientation_pct": 4.5,
+      "unresolved_hops": 0
+    },
+    "unranked_nodes_encountered": 0
+  },
+  "raw_8954": {
+    "n_chains": 8954,
+    "n_hops": 62923,
+    "stage_order": {
+      "monotonic_non_decreasing": 5926,
+      "monotonic_pct": 66.2,
+      "strictly_increasing": 4775,
+      "strictly_increasing_pct": 53.3,
+      "chains_with_an_inversion": 3028,
+      "chains_with_an_inversion_pct": 33.8,
+      "inversions_per_chain_hist": {
+        "0": 5926,
+        "1": 1951,
+        "2": 807,
+        "3": 211,
+        "4": 56,
+        "5": 3
+      },
+      "most_common_inversions_rank_pairs": [
+        [
+          "5->4",
+          2337
+        ],
+        [
+          "4->3",
+          595
+        ],
+        [
+          "6->5",
+          467
+        ],
+        [
+          "2->1",
+          434
+        ],
+        [
+          "3->2",
+          228
+        ],
+        [
+          "6->2",
+          105
+        ],
+        [
+          "5->1",
+          88
+        ],
+        [
+          "6->3",
+          44
+        ],
+        [
+          "5->3",
+          40
+        ],
+        [
+          "6->4",
+          29
+        ]
+      ]
+    },
+    "edge_direction": {
+      "chains_all_hops_forward": 5611,
+      "chains_all_hops_forward_pct": 62.7,
+      "chains_with_a_backward_hop": 3343,
+      "chains_with_a_backward_hop_pct": 37.3,
+      "hops_backward": 4964,
+      "hops_backward_pct": 7.9,
+      "backward_hops_per_chain_hist": {
+        "0": 5611,
+        "1": 2135,
+        "2": 890,
+        "3": 243,
+        "4": 63,
+        "5": 8,
+        "6": 2,
+        "8": 2
+      },
+      "relation_types_walked_forward": [
+        [
+          "validated_by",
+          11174
+        ],
+        [
+          "implemented_by",
+          10845
+        ],
+        [
+          "caused_by",
+          9798
+        ],
+        [
+          "motivates",
+          9613
+        ],
+        [
+          "mitigated_by",
+          9042
+        ],
+        [
+          "enabled_by",
+          3380
+        ],
+        [
+          "addressed_by",
+          1796
+        ],
+        [
+          "refined_by",
+          1577
+        ],
+        [
+          "specified_by",
+          427
+        ],
+        [
+          "required_by",
+          192
+        ],
+        [
+          "enables",
+          103
+        ],
+        [
+          "exacerbated_by",
+          6
+        ],
+        [
+          "motivated_by",
+          3
+        ],
+        [
+          "design rationale",
+          1
+        ],
+        [
+          "extended_by",
+          1
+        ],
+        [
+          "design_rationale_for",
+          1
+        ]
+      ],
+      "relation_types_walked_backward": [
+        [
+          "validated_by",
+          2484
+        ],
+        [
+          "implemented_by",
+          667
+        ],
+        [
+          "motivates",
+          614
+        ],
+        [
+          "mitigated_by",
+          456
+        ],
+        [
+          "enabled_by",
+          297
+        ],
+        [
+          "refined_by",
+          123
+        ],
+        [
+          "caused_by",
+          118
+        ],
+        [
+          "required_by",
+          99
+        ],
+        [
+          "specified_by",
+          60
+        ],
+        [
+          "addressed_by",
+          27
+        ],
+        [
+          "preceded_by",
+          7
+        ],
+        [
+          "addresses",
+          7
+        ],
+        [
+          "enables",
+          3
+        ],
+        [
+          "mitigates",
+          2
+        ]
+      ],
+      "hops_against_type_majority_orientation": 4955,
+      "hops_against_type_majority_orientation_pct": 7.9,
+      "unresolved_hops": 0
+    },
+    "unranked_nodes_encountered": 0
+  }
+}

--- a/paper/OPEN_ITEMS.md
+++ b/paper/OPEN_ITEMS.md
@@ -765,9 +765,15 @@ number in the paper and is discussed nowhere beyond the source-type mix.
 excluding references is the ceiling at conferences as well as workshops, so there is no
 target under which the current draft fits.
 
-Estimated body after the 2026-08-15 pass: **~12.5–13 pages**, down from ~15–16. That
-estimate is a character-count heuristic, not a build — **compile on Overleaf and read the
-real number before deciding what else to cut.**
+🔴 **MEASURED 2026-08-17 on the compiled PDF, and the estimate below was optimistic by two
+pages.** `AISafetyIntervention_PaperA_shared_long.pdf` is 27 pages; the body runs pages 1 to
+15 with References beginning 89% down page 15, so the main body excluding references is
+**~14.9 pages and the gap is ~5 pages, not ~3.** The scoped, agreement-ranked cut package
+that closes it lives in `paper/section_cut_list.md`, built from the 2026-08-17 six-review
+round — work the cuts there, not here.
+
+Earlier estimate, superseded: body after the 2026-08-15 pass **~12.5–13 pages**, down from
+~15–16. That estimate was a character-count heuristic, not a build.
 
 🔴 **The 2026-08-16 pass did not close this gate, and the arithmetic says why.** Measured on
 non-comment source lines at commit `337d033` against `06c3440`: the appendices lost **90

--- a/paper/OPEN_ITEMS.md
+++ b/paper/OPEN_ITEMS.md
@@ -68,6 +68,8 @@ add one). Every study gets a GitHub issue and a PR.
 | + | S6 remainder: baselines B/C/D + unconditioned repeat arm | ✅ done | #171 / PR #170 | `sec:r-stages`, `sec:limitations`, `app:ablation` |
 | + | S2: judge the chain-yielding population | ✅ done | #172 / PR #170 | `sec:r-judge`, `sec:limitations`, abstract, conclusion |
 | + | What a chain count is a function of | ✅ done | #168 follow-up | `sec:limitations` |
+| + | Chain order + edge orientation: does an undirected enumerator yield a directed argument? | ✅ done | #173 / PR #174 | `sec:m-paths`, `tab:cuts` |
+| + | Third review round (3 models x 2 bars) + the cut list built from it | ✅ done | PR #174 | nine `\CUTNOTE{}` scaffold blocks; `paper/section_cut_list.md` |
 
 🔴 **S2 changed a claim rather than confirming one.** Node-level omission on the
 chain-yielding population is **26.4%** against the corpus-sampled run's 0.6%, edge-level

--- a/paper/review_multi_model.py
+++ b/paper/review_multi_model.py
@@ -106,6 +106,21 @@ load-bearing for its claims.
 insight for the paper's findings or key messages -- "sausage-making" from the \
 analysis effort that does not belong in the final paper. Name each one and say \
 what to cut.
+
+4. Length triage against a hard page budget. The main body of this paper (title \
+through the AI-assistance statement, excluding references and appendices) runs to \
+about 15 pages. It must reach 10. Identify the material whose removal is LEAST \
+likely to change the scores you gave above, and say for each item:
+
+   - what it is, and where it sits (section, table or figure number);
+   - move to appendix, or delete outright, and why that choice;
+   - your estimate of the pages recovered;
+   - the effect on your scores: none, minor, or a named score that would drop.
+
+   Order the list by pages recovered per unit of score risk, most favourable \
+first, and state the running total so it is visible where 5 pages have been \
+reached. Then name separately the material you would refuse to move or cut, and \
+say which score depends on it.
 """
 
 PROMPT_WORKSHOP_SUFFIX = """\

--- a/paper/reviews_2026-08-17/gemini31pro_conference.md
+++ b/paper/reviews_2026-08-17/gemini31pro_conference.md
@@ -1,0 +1,100 @@
+Here is the review of the submission, adopting the persona of an expert NeurIPS reviewer, followed by the specific flags and the requested length triage.
+
+***
+
+### Strengths and Weaknesses
+
+**Strengths:**
+*   **Originality and Task Formulation:** The paper introduces a highly novel extraction task: moving beyond entity or citation extraction to capture the *causal-interventional mechanism chain* of safety literature. Treating a paper’s argument as a typed graph (Risk $\rightarrow$ Problem Analysis $\rightarrow$ Theoretical Insight $\rightarrow$ Design Rationale $\rightarrow$ Implementation $\rightarrow$ Validation $\rightarrow$ Intervention) is a fresh, highly valuable contribution to AI safety coordination.
+*   **Methodological Transparency:** The authors exhibit an exceptional level of intellectual honesty and rigor regarding the artifacts produced by their pipeline. The detailed breakdowns of LLM-as-judge omission rates, threshold sensitivities, and structural bottlenecks demonstrate a deep understanding of the limitations of automated graph construction.
+*   **Reproducibility:** The submission includes comprehensive prompts, clear configuration details, and the resulting artifact (the graph and the 2,772 gate-selected chains). The detailed appendices (e.g., constraint lists, rubrics) make the pipeline highly reproducible.
+*   **Significance:** The AI safety community desperately needs tools to navigate a rapidly expanding, heterogeneous literature. Moving from document-level indexing to mechanism-level retrieval is a meaningful leap that researchers and policymakers can directly build upon.
+
+**Weaknesses:**
+*   **Evaluation Relies Entirely on LLM-as-a-Judge:** As the authors acknowledge, no human adjudicated the extraction fidelity. While cross-provider LLM auditing (using Claude to audit o3) mitigates some self-preference bias, it does not confirm if the extracted graph matches the human-perceived ground truth of the paper's argument. An evaluation on a small, human-annotated sample is a glaring omission for a paper of this scope.
+*   **Structural Bloat and Meta-Narrative:** The paper reads less like a traditional scientific manuscript and more like an exhaustive post-mortem of the authors' internal development process. Extensive space is devoted to debunking previous internal findings or discussing experimental setups that failed, distracting from the final, functional artifact.
+*   **Length Violation:** The main text (excluding references/appendices) runs to roughly 15 pages, flagrantly violating the standard 9-10 page conference limit. Substantial triage is required (detailed in the specific flags below).
+
+### Scores
+
+**Quality:** 4 (Excellent) - The technical approach is sound, the dataset generation is rigorous, and the ablations are comprehensive. The lack of a human baseline is the only thing holding the methodology back.
+**Clarity:** 3 (Good) - The writing is precise, but the organization is hampered by a conversational, investigative tone and the inclusion of unnecessary "sausage-making." 
+**Significance:** 4 (Excellent) - The resulting dataset and the proposed pipeline offer a high-impact resource for the AI safety community.
+**Originality:** 4 (Excellent) - Formulating literature extraction as a typed causal-mechanism chain is highly innovative and well-executed.
+**Overall:** 5 (Accept) - Technically solid paper with high impact, rigorous evaluation of its own artifacts, and excellent reproducibility. Revisions for length and tone are mandatory, but the core contribution is undeniably strong.
+**Confidence:** 4 - I am confident in my assessment, familiar with the LLM information-extraction literature and the general state of AI safety datasets.
+
+### Questions
+
+1.  **Human Evaluation Baseline:** The limitations section rightly notes that a human-annotated sample is the "missing instrument." Given that the LLM judge found massive discrepancies depending on the framing (e.g., 0.6% node omission vs 18.1% edge omission), why was a small human sample (e.g., $N=20$ papers) not used to anchor the ground truth of the extraction? Is it feasible to add this to a revision?
+2.  **Vocabulary Rigidity:** The pipeline enforces a strict 5-stage intermediate vocabulary. Section 3.1 shows that when this is removed, the model invents 144 categories. However, forcing all AI safety papers into this specific 5-stage causal chain might induce hallucinations of structure where none exists (as seen in the math paper failure case in Appendix P). How do you plan to handle literature that is purely theoretical or purely empirical without forcing it into this rigid schema?
+3.  **Handling of Overlapping Arguments:** Section 2.5 notes that the sub-path collapse drops 18% of distinct risk-to-intervention pairs. How confident are the authors that this greedy collapse isn't throwing away valuable, distinct sub-mechanisms that happen to share a dense neighborhood with a longer chain?
+
+### Limitations
+
+The authors have addressed the limitations of their work with an almost unprecedented level of detail (Section 6 spans two pages). They thoroughly discuss the limits of LLM-internal validation, the distinction between structural completeness and extraction fidelity, and the potential biases introduced by their gating criteria. They have also properly addressed potential misuse and ethical concerns in the Impact Statement. No further additions are needed here; if anything, the limitations section needs to be condensed.
+
+***
+
+### Specific Flags Requested
+
+#### 1. Unscientific or Unacademic Writing Style
+The paper features a highly idiosyncratic, conversational, and occasionally legalistic tone that breaks standard academic conventions. Examples to revise:
+*   *"Two things follow for how the rest of this paper should be read, and we state them here. What we release is the graph... What we analyse is an example..."* (Section 1). This reads like a blog post or manifesto. State contributions directly without the meta-commentary on "how the paper should be read."
+*   *"One evaluation design that answers nothing."* (Section 3.2 header). Too colloquial.
+*   *"One measurement artifact to separate before quoting any error rate."* (Section 3.2 header).
+*   *"Read those rows for portability rather than for capability..."* (Section 6.1). Imperative directives to the reader should be rephrased as objective statements about the data's utility.
+
+#### 2. Outsized Importance to Non-Load-Bearing Aspects
+*   **The "Meta-Grader" setup (Section 3.2):** The authors spend almost half a page detailing the setup and failure of three meta-graders scoring extractions before and after repairs. Because the setup was unblinded and lacked a null-repair arm, the authors admit it is totally confounded. Treating this methodological misstep as a headline finding gives it outsized importance.
+*   **Sections 4.4 and 4.5 (Importance Ranking & Framing Analysis):** These sections are framed entirely around debunking an "earlier internal pass of this project." While the message—that pipeline artifacts heavily distort centrality and clustering metrics—is important, dedicating over a page and a large figure (Figure 4) to disproving an unpublished internal draft centers the paper on a non-issue. 
+
+#### 3. Unsuccessful Designs / Sausage-Making to Cut
+*   **Section 3.2, "One evaluation design that answers nothing":** Cut the entire paragraph discussing the pre/post grader scoring. It yields no actionable insight for the reader beyond "we designed a bad experiment."
+*   **Section 4.5, "Framing analysis: co-occurrence measured on a centrality-selected head does not reproduce":** Cut this section. It is pure sausage-making about an internal pipeline iteration that failed. The core warning about graph selection artifacts is already made (and can be summarized) in 4.4.
+
+#### 4. Length Triage (Targeting ~5 pages of cuts to reach a 10-page limit)
+
+Here is the prioritized list of material to move or delete, ordered by pages recovered per unit of score risk (most favorable first). 
+
+**Running Total: 0.0 pages saved**
+
+1.  **What & Where:** Section 3.2, headers "One evaluation design that answers nothing" and "One measurement artifact to separate before quoting any error rate."
+    **Action:** Delete outright. The evaluation design is admitted to be useless (confounded), and the measurement artifact is a schema-versioning bug that belongs in a GitHub issue or footnote, not the main text.
+    **Pages recovered:** ~0.5 pages.
+    **Score effect:** None (Clarity score might actually *increase*).
+    **Running Total:** 0.5 pages.
+
+2.  **What & Where:** Section 4.4 and Section 4.5 (Importance ranking and Framing analysis) and Figure 4.
+    **Action:** Move to Appendix. The deep autopsy of how node-merging creates a "centrality super-hub" and ruins framing analysis is an interesting cautionary tale, but it is fundamentally an analysis of a flawed *internal* iteration of the pipeline. Replace these 1.5 pages with a single paragraph warning against naive centrality/clustering calculations on LLM-generated graphs.
+    **Pages recovered:** ~2.0 pages (including the large Figure 4).
+    **Score effect:** None.
+    **Running Total:** 2.5 pages.
+
+3.  **What & Where:** Section 6.1 (Limitations). 
+    **Action:** Condense heavily. Move the detailed numerical re-litigation (e.g., the paragraph starting "Single extractor, and a run-to-run floor...") to an Appendix titled "Detailed Run-to-Run Variance." The main text limitations should be succinct bullet points, as they largely repeat numbers already presented in Section 3.
+    **Pages recovered:** ~1.0 pages.
+    **Score effect:** Minor risk to Quality if condensed poorly, but generally safe if the core qualitative limitations remain. 
+    **Running Total:** 3.5 pages.
+
+4.  **What & Where:** Section 4.3 (Topical navigation) paragraph on UMAP vs. original space silhouette scores.
+    **Action:** Move to Appendix. The technical debate over which space to calculate the silhouette score in is a distraction from the section's main point (that semantic clustering is too weak for mechanism grouping).
+    **Pages recovered:** ~0.4 pages.
+    **Score effect:** None.
+    **Running Total:** 3.9 pages.
+
+5.  **What & Where:** Table 1 (Mechanism retrieval examples).
+    **Action:** Move Query 2 to the Appendix and keep only Query 1 in the main text. 
+    **Pages recovered:** ~0.4 pages.
+    **Score effect:** None.
+    **Running Total:** 4.3 pages.
+
+6.  **What & Where:** Section 2.5 (From Path Enumeration to the Reporting Unit). 
+    **Action:** Move the dense statistical breakdown of "What the step drops" to the Appendix. The main text only needs to state the greedy longest-first strategy and the final yield (2,772 chains).
+    **Pages recovered:** ~0.5 pages.
+    **Score effect:** None.
+    **Running Total:** 4.8 pages. (Close enough to the 5-page reduction goal).
+
+**Material to REFUSE to cut:**
+*   **Sections 2.2 and 2.6 (Pipeline & LLM-as-Judge Protocols):** The exact pipeline configurations and the framing of the auditing stage are load-bearing for the paper's **Quality** and **Originality** scores.
+*   **Section 3.1 and 3.2 (Yields and Sample-scale Auditing):** The quantitative results of the pipeline and the frank reporting of omission errors (the 26.4% node / 21.7% edge omission on chain-yielding documents) are the most scientifically valuable findings in the paper. Removing these would severely damage the **Significance** and **Quality** scores.

--- a/paper/reviews_2026-08-17/gemini31pro_conference.meta.json
+++ b/paper/reviews_2026-08-17/gemini31pro_conference.meta.json
@@ -1,0 +1,11 @@
+{
+  "provider": "gemini",
+  "model": "gemini-3.1-pro-preview",
+  "mode": "conference",
+  "elapsed_sec": 65.3,
+  "response_chars": 11513,
+  "generated_utc": "2026-08-17T13:34:31+00:00",
+  "stop_reason": "FinishReason.STOP",
+  "input_tokens": 15643,
+  "output_tokens": 2559
+}

--- a/paper/reviews_2026-08-17/gemini31pro_workshop.md
+++ b/paper/reviews_2026-08-17/gemini31pro_workshop.md
@@ -1,0 +1,108 @@
+Here is a comprehensive review of the submission, tailored for a **workshop** acceptance context, followed by the specific structural and stylistic feedback requested.
+
+### Strengths and Weaknesses
+
+**Strengths:**
+*   **Originality & Task Design:** The shift from standard document-level indexing (or standard entity extraction) to extracting *causal-interventional mechanism chains* (Risk -> Problem -> Insight -> Rationale -> Implementation -> Validation -> Intervention) is highly novel and extremely relevant to the AI safety community. 
+*   **Scale and Transparency:** Applying this pipeline to 11,779 documents to produce a 200k-node graph is a massive effort. The authors are brutally honest about the limitations of zero-shot LLM extraction and LLM-as-a-judge protocols, providing a refreshing level of transparency.
+*   **Methodological Rigor on Artifacts:** The paper brilliantly identifies how standard graph operations (like similarity merging) create artificial "super-hubs" (e.g., existential risk becoming artificially central). Identifying these graph-construction artifacts is a major contribution to the science of LLM-generated knowledge graphs.
+*   **Suitability for a Workshop:** The work is perfectly scoped for a workshop. It presents a novel dataset, a new pipeline, and highly discussable findings regarding the limits of automated knowledge extraction.
+
+**Weaknesses:**
+*   **Narrative Structure & Focus:** The paper spends an immense amount of the main text detailing failed post-hoc analyses, debugging artifacts, and flawed evaluation setups. While intellectually honest, this obscures the actual utility of the dataset.
+*   **Unadjudicated Evaluation:** The LLM-as-a-judge evaluation is completely internal (no human adjudication). While the authors acknowledge this, the lack of even a small (e.g., n=50) human-annotated ground-truth sample makes it difficult to assess the true fidelity of the extracted chains.
+*   **Formatting and Length:** The main body is ~15 pages, well over standard conference/workshop limits (typically 9-10 pages for main tracks, often shorter for workshops).
+
+---
+
+### Scores
+
+**Quality:** 4
+**Clarity:** 3
+**Significance:** 4
+**Originality:** 4
+
+---
+
+### Questions & Suggestions for Authors
+
+1.  **Human Ground Truth:** Can you annotate a small sample (e.g., 30-50 documents) with human experts to establish a true baseline for extraction fidelity? Even a small sample would anchor the LLM-as-a-judge findings and drastically improve the paper's empirical standing.
+2.  **Dataset Utility Focus:** Section 4 highlights how standard network analyses (centrality, clustering) fail on this graph due to pipeline artifacts. Aside from the single retrieval example in 4.1 and basic descriptive stats in 4.2, how *should* researchers use this graph? Adding a successful, robust downstream use-case would strengthen the paper immensely.
+3.  **Reframing Section 4:** Consider reframing sections 4.3, 4.4, and 4.5. Currently, they read as "we tried this, it failed, here is why you shouldn't do it." Reframe this as a dedicated "Methodological Pitfalls in LLM-KGs" section to highlight that discovering these artifacts is a *contribution*, not just a failed experiment.
+
+---
+
+### Limitations
+**Yes.** The authors have gone above and beyond in addressing limitations. In fact, the paper is almost entirely composed of limitations, caveats, and controls. The ethical considerations (e.g., misattribution of claims, dual-use of mapping weak interventions) are handled exceptionally well in the Impact Statement.
+
+---
+
+### Overall Score
+**5: Accept** (Workshop Context)
+*Rationale:* For a workshop, this is a highly solid, impactful paper. It provides a unique dataset, a novel approach to literature organization, and crucial insights into the artifacts of LLM-generated KGs. The technical execution is solid, and the transparency is commendable, even if the paper needs heavy editing for length and narrative focus.
+
+---
+
+### Confidence Score
+**4**: Confident in assessment, but not absolutely certain. (Familiar with LLM knowledge extraction and AI safety literature, but did not forensically verify the provided code/receipts).
+
+***
+
+### Specific Feedback: Style, Outsized Importance, Sausage-Making, and Length Triage
+
+#### 1. Unscientific or Unacademic Writing Style
+The paper does not read as LLM-generated (it entirely lacks the typical sycophantic, flowery LLM boilerplate). However, it frequently slips into a highly informal, conversational, or overly "meta-discursive" style that feels more like a LessWrong blog post than a peer-reviewed paper. 
+*   *Examples:* "Two things follow for how the rest of this paper should be read, and we state them here." / "One evaluation design that answers nothing." / "What the step drops, measured against what displaced it."
+*   *Fix:* Remove conversational signposting. Let the section headers and topic sentences do the work. (e.g., Change "One evaluation design that answers nothing" to simply "Confounded Meta-Grader Evaluation").
+
+#### 2. Outsized Importance to Non-Load-Bearing Aspects
+The authors place outsized importance on *why* their evaluation pipeline broke, rather than what it means for the data. 
+*   *Example:* The deep dive into the json schema mismatch in Section 3.2 ("One measurement artifact to separate before quoting any error rate"). The fact that the judge expected inline rationales but the extractor output separate rationale nodes is a simple bug. Dedicating a bolded paragraph in the main text to explain why this generated an 84% blocker-severity error rate elevates a minor software engineering mismatch to the level of a scientific finding. 
+
+#### 3. Sausage-Making (Content to Cut)
+The paper includes methodological failures that yield no load-bearing insights and should be cut or relegated to an appendix.
+*   **"One evaluation design that answers nothing" (Section 3.2):** You ran meta-graders without blinding them to the judge's proposed repairs, realized the results were confounded, and learned nothing. *Action: Delete outright.* This is pure sausage-making that wastes reviewer and reader time.
+*   **"One measurement artifact to separate..." (Section 3.2):** The schema bug mentioned above. *Action: Delete from main text.* Just report the error rates *excluding* the schema mismatch, and add a one-sentence footnote explaining the exclusion.
+*   **Section 4.3, 4.4, 4.5 (Failed Analyses):** You ran clustering, centrality, and co-occurrence framing analyses, discovered they were distorted by your own pipeline's artifacts (e.g., UMAP distortion, node-merging transitive closures), and spent 2.5 pages explaining why these analyses are broken. While the discovery of the artifact is interesting, detailing the initial flawed premise is sausage-making. 
+
+#### 4. Length Triage (15 pages to 10 pages)
+*Target: Cut 5 pages.*
+
+Here is the prioritized list of cuts, ordered by pages recovered per unit of score risk (most favorable first). 
+
+1.  **Section 4.3, 4.4, 4.5 (Topical Navigation, Importance Ranking, Framing Analysis)**
+    *   *Where it sits:* Pages 9–12 (including Figure 4 and Table 1).
+    *   *Action:* Move to Appendix. Replace with a single half-page section titled "Artifacts in Graph Structural Analysis" summarizing that naive clustering, centrality, and co-occurrence fail on this graph due to transitive merge closures and similarity-layer density.
+    *   *Pages recovered:* ~2.5 pages.
+    *   *Effect on score:* **None.** These sections show what *not* to do with the graph. Moving the lengthy proof of these negative results to the appendix tightens the paper without losing the core contribution.
+2.  **Section 6.1 (Limitations)**
+    *   *Where it sits:* Pages 13–14.
+    *   *Action:* Move almost entirely to the Appendix. 
+    *   *Why:* The paper is already heavily caveated inline. You do not need to spend 1.5 pages at the end repeating that the baseline is internal, the audit covers 100 documents, and the extraction is a single run. Keep one short paragraph summarizing the limits.
+    *   *Pages recovered:* ~1.5 pages.
+    *   *Effect on score:* **None.** The limitations are well-documented elsewhere in the text; consolidating them in the appendix preserves intellectual honesty while saving space.
+3.  **Sausage-Making in Section 3.2**
+    *   *Where it sits:* Page 9 ("One evaluation design that answers nothing" & "One measurement artifact...").
+    *   *Action:* Delete outright.
+    *   *Why:* As noted above, failed unblinded grader setups and JSON schema bugs are not scientific contributions.
+    *   *Pages recovered:* ~0.5 pages.
+    *   *Effect on score:* **None / Minor increase in Clarity.**
+4.  **Section 3.1 Ablations ("Removing the five stages..." & "Three simpler pipelines...")**
+    *   *Where it sits:* Pages 6–7.
+    *   *Action:* Move to Appendix O (which already houses some of this). 
+    *   *Why:* N=30 ablations showing that an LLM extracts less structure when you don't prompt it for structure is highly expected and doesn't require main-text real estate. 
+    *   *Pages recovered:* ~0.5 pages.
+    *   *Effect on score:* **None.**
+5.  **Section 2.5 ("What the step drops...")**
+    *   *Where it sits:* Page 4.
+    *   *Action:* Move the detailed statistical breakdown of the dropped 70% subsumption paths to the Appendix.
+    *   *Why:* It is overly granular for the methods section. You only need to state that you collapsed the paths to distinct arguments.
+    *   *Pages recovered:* ~0.3 pages.
+    *   *Effect on score:* **None.**
+
+*(Running Total: ~5.3 pages recovered. The paper is now at the 10-page limit.)*
+
+**Material I would REFUSE to cut:**
+*   **Section 1 & 2.1/2.2/2.4:** The motivation, schema definition, and pipeline design. *Score dependency:* **Quality & Originality**.
+*   **Section 3.1 (Yield statistics) and 3.2 (Omission dominates errors):** The core results of the pipeline and the primary audit findings. *Score dependency:* **Quality & Significance**.
+*   **Section 4.1 (Mechanism Retrieval):** The only true positive use-case demonstrated in the paper. *Score dependency:* **Significance**. Without this, the paper builds a dataset but fails to prove it can be used for anything.

--- a/paper/reviews_2026-08-17/gemini31pro_workshop.meta.json
+++ b/paper/reviews_2026-08-17/gemini31pro_workshop.meta.json
@@ -1,0 +1,11 @@
+{
+  "provider": "gemini",
+  "model": "gemini-3.1-pro-preview",
+  "mode": "workshop",
+  "elapsed_sec": 50.5,
+  "response_chars": 10214,
+  "generated_utc": "2026-08-17T13:34:16+00:00",
+  "stop_reason": "FinishReason.STOP",
+  "input_tokens": 15688,
+  "output_tokens": 2412
+}

--- a/paper/reviews_2026-08-17/gpt56sol_conference.md
+++ b/paper/reviews_2026-08-17/gpt56sol_conference.md
@@ -1,0 +1,429 @@
+## Summary and recommendation
+
+This paper introduces a large-scale, full-text LLM pipeline for extracting typed risk-to-intervention argument chains from 11,779 documents in the Alignment Research Dataset. It produces a 200,525-node provenance-bearing graph and a filtered reporting set of 2,772 chains. A cross-provider LLM judge audits two 100-document samples, and the paper presents several downstream analyses and extensive diagnostics of graph-construction artifacts.
+
+The task and resulting artifact are potentially valuable, and the paper is unusually candid about its negative results, instability, and limitations. However, the central object—the extracted mechanism chain—has not been evaluated against human annotations. The LLM-only audit is internally inconsistent, uses non-comparable denominators, and does not evaluate the two attributes that determine the main reporting set. In addition, path extraction ignores edge direction and apparently does not enforce monotonic stage order, so an enumerated “chain” need not be a logically directed risk-to-intervention argument. The arbitrary path-collapse rule removes 18% of distinct risk–intervention pairs, and chain membership is unstable across reruns. These issues substantially weaken the technical validity of the released chain set and its claimed uses.
+
+I lean **borderline reject**. A modest, stratified human evaluation and clarification/correction of the path semantics and audit estimands could materially change my assessment.
+
+---
+
+# Strengths and weaknesses
+
+## Strengths
+
+### Quality
+
+1. **A useful and well-motivated extraction target.**  
+   Extracting the internal argument connecting a risk to an intervention is meaningfully different from clustering papers by title, abstract, or topic. The typed stages—problem analysis, theoretical insight, design rationale, implementation mechanism, and validation evidence—provide a potentially useful representation for literature navigation.
+
+2. **Substantial scale and provenance.**  
+   Processing 11,779 full documents and retaining source-level provenance is a nontrivial engineering contribution. The separation between single-document structural edges and cross-document similarity edges is conceptually clean and important.
+
+3. **Strong sensitivity and artifact analysis.**  
+   The gate sweep in Table 7 is particularly informative: it shows that document yield moves from 15.9% to 99.4% depending on two model-assigned thresholds. The analysis of merge-induced centrality artifacts is also useful and demonstrates that seemingly substantive graph findings can be consequences of graph construction.
+
+4. **Unusually honest reporting.**  
+   The paper reports schema forcing, shuffled-input failures, run-to-run instability, confounded grader experiments, and a concrete spurious chain. This candor is a major strength. The authors frequently distinguish corpus composition from claims about the field.
+
+5. **Considerable reproducibility detail in the manuscript.**  
+   Prompts, rubrics, traversal constraints, model configurations, and population definitions are documented more thoroughly than in most LLM extraction papers.
+
+### Clarity
+
+1. The main pipeline is easy to understand, and Figures 1–3 communicate the extraction and filtering process effectively.
+2. The EDGE/SIM distinction and provenance model are explained clearly.
+3. The appendices provide unusually complete methodological documentation.
+4. The paper repeatedly states which analyses are descriptive and which should not be interpreted as findings about the AI safety literature.
+
+### Significance
+
+1. A trustworthy mechanism-indexed corpus could be useful for literature review, research coordination, evidence mapping, and identifying repeated or missing intervention mechanisms.
+2. The graph-construction diagnostics are relevant beyond AI safety. In particular, the merge/centrality and UMAP/silhouette results are useful warnings for knowledge-graph and literature-mapping work.
+3. The released extraction schema and provenance-bearing graph could become useful research infrastructure if fidelity is established.
+
+### Originality
+
+1. The specific risk-to-intervention mechanism-chain task is original and well motivated.
+2. The contribution is a novel combination of full-text schema-guided extraction, provenance-preserving graph construction, and downstream artifact diagnostics.
+3. The paper contains several useful negative insights about schema forcing and graph post-processing, even though the underlying methods—prompted extraction, LLM judging, embeddings, DFS, and clustering—are individually standard.
+
+---
+
+## Weaknesses
+
+### Quality
+
+#### 1. The central extraction has no human-grounded fidelity evaluation
+
+This is the main weakness. The extractor is judged by another LLM, and the meta-evaluation is performed by further LLMs. Cross-provider agreement reduces self-preference concerns but does not establish source faithfulness. The stage relabeling result, \(\kappa=0.84\), establishes that two models can apply the same definitions consistently; it does not show that the extracted nodes are supported by the source or that the five-stage ontology is appropriate.
+
+This concern is not hypothetical. The paper presents a fully gate-passing Euclid/prime-number chain whose risk framing and intervention are invented. The shuffled-sentence control also produces chains for 30% of documents. These results imply that structural conformance and model-assigned edge confidence are inadequate substitutes for fidelity evaluation.
+
+The paper deserves credit for acknowledging this, but acknowledgment does not make the corpus technically validated.
+
+#### 2. The headline “omission rates” are not well-defined omission rates
+
+The three reported quantities use flagged additions divided by the size of the existing extraction:
+
+- \(9/1617=0.6\%\) proposed added nodes,
+- \(302/1667=18.1\%\) missing relationships relative to existing graph edges,
+- \(216/751=28.8\%\) grader-recorded missed concepts relative to existing nodes.
+
+These denominators are not aligned with the judged items. In particular, the judge’s coverage list contains 777 expected relationships, of which 302 are marked missing; within that instrument, the missing fraction is \(302/777=38.9\%\), not 18.1%. On the second run it is \(476/627=75.9\%\), although the paper instead reports \(476/2192=21.7\%\) by dividing by graph edges that were not necessarily enumerated by the coverage instrument.
+
+Because the expected-edge list is itself neither exhaustive nor human-adjudicated, even 38.9% is not a corpus omission rate. The quantities are better described as “judge-proposed additions per extracted item.” They are neither demonstrated upper bounds nor lower bounds: the judge can both invent omissions and fail to notice omissions.
+
+This is especially problematic because these figures appear prominently in the abstract and conclusion.
+
+#### 3. The two audit runs are not comparable
+
+The change from added nodes in 7/100 documents to 95/97 documents is enormous. The second run differs in document length, source mixture, and extraction serialization, including omitted rationale fields. Therefore, the paper cannot infer a population “direction” or a “floor” from the comparison. The result instead indicates that the audit instrument is highly sensitive to input representation or population.
+
+Before these results can support extraction quality claims, the authors need either a matched comparison or a diagnosis of why nominally the same protocol changed so dramatically.
+
+#### 4. The path enumerator does not establish a directed logical mechanism chain
+
+The enumerator ignores edge direction because relation types use mixed orientations. However, the extracted object is described as a logical risk-to-intervention mechanism chain. An undirected traversal through typed relations establishes connectivity, not necessarily a directed argument.
+
+It is also unclear whether stage order is enforced. The listed constraints require a risk root, an intermediate first hop, and an intervention endpoint, but do not require categories to progress monotonically through the canonical order. A path could apparently move from problem analysis to validation evidence to theoretical insight and still count as containing all stages. Similarly, a low-maturity intervention can occur inside the path.
+
+The paper should report:
+
+- the fraction of paths with monotonic stage order;
+- the fraction whose edge semantics are consistent with the claimed risk-to-intervention reading;
+- results after canonicalizing relation direction;
+- how many retained chains contain internal intervention nodes.
+
+Without this, “chain” is stronger terminology than the construction supports.
+
+#### 5. The reporting unit is arbitrary and lossy
+
+The 70% node-containment collapse reduces 8,954 paths to 2,772 chains, but:
+
+- 78.3% of dropped paths contain a node absent from their container;
+- 28.0% terminate at a different intervention;
+- 18.0% of distinct risk–intervention pairs disappear;
+- the count changes from 2,658 to 5,460 as the threshold moves from 0.60 to 0.90.
+
+The paper explicitly states that it does not know whether these are distinct arguments. Therefore, the 2,772-chain set should not be described as one record per distinct argument without manual validation. Reporting document-level or endpoint-pair-level statistics alongside the collapse would be safer.
+
+#### 6. The two gates are unvalidated and unstable
+
+Edge confidence and intervention maturity select the main chain set, but neither is evaluated by the judge. Moreover:
+
+- the gates change document yield from 15.9% to 99.4%;
+- they strongly change venue composition;
+- on a rerun, only 9 of 18 parseable extractions from previously chain-yielding documents still yield a chain;
+- the paper’s confidence rubric conflates source support with evidentiary strength.
+
+An explicit conceptual claim may receive confidence 2 because it is not empirically supported, while a systematic qualitative claim may receive 3. Thus, “confidence \(\ge 3\)” is not simply a fidelity filter. It selects a particular kind of evidence and venue.
+
+The main results should either be presented across gates or based on calibrated human labels. A single thresholded set is currently too contingent to be the primary reporting unit.
+
+#### 7. The baselines and use-case evaluation are limited
+
+The abstract-only, non-reasoning-model, schema ablation, and flat-triple comparisons are run on small internal samples, mostly \(n=25\) or \(30\). There is no independent extraction baseline, no annotated benchmark, and no statistical uncertainty.
+
+The retrieval use case consists of two hand-selected examples with no query set, relevance judgments, source-faithfulness evaluation, or comparison against BM25, dense retrieval, or document-level RAG. The paper establishes addressability, not retrieval superiority.
+
+#### 8. The “scalable pipeline” claim is only partly established
+
+The extraction stage is linear in the number of input documents, but the full pipeline includes:
+
+- a judge that is only run at sample scale;
+- similarity construction that can be quadratic without approximate search;
+- path enumeration that the paper itself shows can explode with modest increases in mean degree;
+- output and reasoning token costs reconstructed from incomplete logs.
+
+The title would be more defensible as “A large-scale extraction pipeline” unless end-to-end scaling behavior is measured.
+
+#### 9. The submitted artifact is incomplete as presented
+
+The manuscript contains a missing release URL and unresolved editorial placeholders for authorship, acknowledgments, and AI-assistance scope. The claimed release is central to the paper’s significance and reproducibility. An anonymized artifact should be available during review, and all internal `[GAP: ...]` notes must be removed from a final submission.
+
+### Clarity
+
+1. **The paper is much too long and repetitive.**  
+   The same caveats—different populations, unvalidated gates, “the stage we ship,” and construction artifacts—are restated multiple times. The transparency is welcome, but the repetition obscures the main empirical message.
+
+2. **Too much project history is included.**  
+   Earlier internal substrates, failed prior analyses, schema-version history, grader-session drift, and stale internal passes are narrated at length. Much of this belongs in an appendix, repository changelog, or postmortem.
+
+3. **The prose is often rhetorically stylized rather than scientific.**  
+   Examples include “We report them all and reconcile none,” “One evaluation design that answers nothing,” and “Two sevens in this subsection are unrelated.” These formulations call attention to the writing rather than clarifying the estimand.
+
+4. **Terminology is occasionally stronger than the evidence.**  
+   “Chain,” “quality gate,” “complete mechanism,” and “omission rate” suggest semantic validation that has not been established.
+
+5. **Twelve populations are difficult to track.**  
+   Table 6 helps, but the main text should organize results around three primary units: all extracted documents, chain-yielding documents, and retained chains.
+
+### Significance
+
+1. The artifact could be significant, but its utility depends strongly on fidelity. A large graph with unknown precision and recall may create additional verification work rather than reduce it.
+2. The corpus ends in 2023, which is a substantial limitation for a rapidly changing field.
+3. Only 15.9% of documents enter the main chain set under the chosen gates, with strong venue bias.
+4. The paper does not evaluate whether researchers actually retrieve better mechanisms, synthesize literature more accurately, or save time using the resource.
+5. The scope is currently niche. The general argument-extraction methodology could broaden the impact, but the present evidence is specific to one safety corpus and one proprietary extractor.
+
+### Originality
+
+1. The task and artifact are original, but the technical pipeline is mostly a composition of standard components.
+2. The five-stage ontology is imposed by the prompt rather than learned or derived from human argument analysis.
+3. The relation to argument mining is discussed, but the paper does not compare against sentence-level argument mining, scientific claim extraction, or structured summarization baselines.
+4. Some of the most interesting findings concern common analysis pitfalls rather than the proposed extraction method itself.
+
+---
+
+# Scores
+
+| Dimension | Score | Rationale |
+|---|---:|---|
+| **Quality** | **2 / 4 — Fair** | Large and carefully documented engineering effort, but central fidelity is not human-evaluated; audit rates are not valid omission estimands; chain semantics and gates are insufficiently validated. |
+| **Clarity** | **2 / 4 — Fair** | Generally intelligible and well organized locally, but excessively long, repetitive, rhetorically stylized, and burdened by internal project history and unresolved placeholders. |
+| **Significance** | **3 / 4 — Good** | A validated mechanism-indexed corpus could be useful to AI safety and literature-mining researchers; current impact is limited by fidelity uncertainty, corpus age, and lack of user/retrieval evaluation. |
+| **Originality** | **3 / 4 — Good** | Novel task, schema, and dataset combination, though the technical components are standard and the ontology is prompt-imposed. |
+
+## Overall score
+
+**3 / 6 — Borderline Reject**
+
+The artifact and task are promising, and the paper’s transparency is exemplary. However, the principal claims depend on a chain set whose faithfulness, directionality, gate labels, and reporting-unit construction have not been adequately validated. The reasons to reject currently outweigh the reasons to accept, but this could change with a relatively focused human evaluation and correction of the audit/path semantics.
+
+## Confidence
+
+**4 / 5**
+
+I am confident in the assessment. The central methodological and evaluation issues are visible from the paper’s own reported results, although I have not inspected the unreleased graph or code.
+
+---
+
+# Questions and actionable requests
+
+## 1. Can the authors provide a human-annotated fidelity evaluation?
+
+Please annotate a stratified sample covering at least arXiv, LessWrong/Alignment Forum, transcripts, chain-yielding documents, and non-chain-yielding documents. At minimum, report:
+
+- node precision and recall against source-supported concepts;
+- edge precision and recall;
+- validity of the complete risk-to-intervention path;
+- whether each intervention is explicitly proposed;
+- human ratings of edge confidence and maturity;
+- inter-annotator agreement and an adjudication protocol.
+
+A smaller but rigorous human study would be more informative than additional LLM graders.
+
+**Score impact:** convincing human evidence of reasonable chain-level precision and useful recall could raise my overall score from **3 to 4 or 5**. Evidence of substantial schema-induced fabrication would lower it to **2** unless the release is reframed as an unvalidated candidate graph.
+
+## 2. What exactly is the audit estimand, and can the headline rates be corrected?
+
+The current 0.6%, 18.1%, 28.8%, 26.4%, and 21.7% quantities divide proposed missing items by the size of an existing graph, even though the numerator and denominator are produced by different instruments. Please:
+
+- stop calling these omission rates unless a common universe is defined;
+- report the judge coverage statuses within the coverage list;
+- distinguish additions per extracted item from recall;
+- explain why the second judge run marks 95/97 documents for node additions;
+- avoid describing any quantity as an upper bound, lower bound, direction, or floor without assumptions that justify it.
+
+**Score impact:** a corrected analysis would improve Quality and Clarity. Retaining the current interpretation would reinforce my borderline-reject assessment.
+
+## 3. Do retained paths preserve the semantics of a directed argument?
+
+Please report the fraction of chains that:
+
+- obey monotonic stage order;
+- have all edge relations oriented consistently after relation-specific direction canonicalization;
+- contain an intervention before the endpoint;
+- require traversing at least one edge against its semantic direction;
+- remain valid under directed rather than undirected traversal.
+
+A manually evaluated sample should determine whether the resulting paths are genuinely coherent mechanisms rather than connected node sequences.
+
+**Score impact:** if a large fraction fails this test, I would lower the overall score to **2**. If nearly all paths remain semantically coherent after canonicalization, this would materially improve Quality.
+
+## 4. Can the gates and 70% collapse be validated or replaced with less brittle reporting?
+
+Please evaluate maturity and edge-confidence labels against human judgments, and report chain-set stability across repeated runs or extractors. For the collapse, manually label whether dropped paths are distinct arguments, particularly those with different interventions.
+
+I suggest making documents and risk–intervention endpoint pairs the primary stable units, with the 2,772 collapsed paths treated as one optional view. Soft weighting by maturity/confidence may also be preferable to a hard gate.
+
+**Score impact:** evidence that the primary findings are stable to reruns and reporting-unit choice could raise Quality. Continued dependence on an unvalidated, unstable gate and lossy collapse is a major reason for my current score.
+
+## 5. Can the retrieval claim be evaluated against realistic baselines, and can the artifact be made available?
+
+Please provide:
+
+- an anonymized release URL during review;
+- a query set with risk/intervention/mechanism information needs;
+- human relevance and source-faithfulness judgments;
+- comparisons against BM25, dense full-text retrieval, and a document-level RAG baseline;
+- latency/cost measurements if scalability is retained as a headline claim.
+
+Also clarify how documents exceeding the model context limit were handled and distinguish extraction-stage scaling from similarity construction, path enumeration, and audit scaling.
+
+**Score impact:** a working artifact is necessary for the paper’s resource contribution. If it remains unavailable, I would consider an overall score of **2**. A useful retrieval benchmark could raise Significance from **3 to 4**.
+
+---
+
+# Limitations
+
+**yes**
+
+---
+
+# Writing-style flags
+
+The following passages are unusually rhetorical, informal, editorial, or read like machine-polished parallel constructions rather than conventional scientific prose.
+
+| Location | Passage or pattern | Concern and suggested revision |
+|---|---|---|
+| Abstract | “We report them all and reconcile none.” | Defiant/rhetorical. Replace with: “Because these instruments are not directly comparable and none is human-adjudicated, we report them separately.” |
+| Introduction | “The stage we audit is the stage we ship…” / “What we analyse is an example…” | Slogan-like repetition. State the two populations once in neutral terms. |
+| Throughout | “the thing we ship,” “the unit it releases,” “reads 26.4%,” “what the gates decide” | Informal or unnatural phrasing. Use “released artifact,” “estimated value,” and “depends on the gate thresholds.” |
+| Section 3.1 heading | “Removing the five stages from the prompt costs the chain, not the vocabulary.” | Rhetorical headline. Use “Ablation of the stage schema reduces complete-chain yield.” |
+| Section 3.1 heading | “Three simpler pipelines, and what each of them loses.” | Promotional and overly categorical for \(n=25\)–30 experiments. Use “Small-sample comparisons with simplified extraction configurations.” |
+| Section 3.2 | “Two sevens in this subsection are unrelated.” | Editorial note that should be removed; rename variables or rewrite the preceding sentences. |
+| Section 3.2 heading | “One evaluation design that answers nothing.” | Informal and absolute. Replace with one sentence in Limitations: “The unblinded pre/post repair scores are not interpretable and are not analyzed.” |
+| Section 3.2 | “The three sort by instrument rather than by unit.” | Opaque. Explicitly define the numerator, denominator, and instrument. |
+| Section 4 | “each with the control it needs” repeated in the introduction, goals, and section opening | Repetitive framing. State this once. |
+| Section 4.4 | “merging near-duplicate nodes manufactures a centrality super-hub” | “Manufactures” is rhetorically loaded. “Induces a dominant centrality hub” is more neutral. |
+| Section 6.1 heading | “Single extractor, and a run-to-run floor that only the counts clear.” | Opaque and stylized. Use “Run-to-run stability of extraction counts and identities.” |
+| Conclusion | “the extension we would prioritize…” | First-person roadmap language is unnecessary. State the highest-priority future work directly. |
+| Page 15 | All `[GAP: ...]` comments and “Author List Placeholder” | These are internal editorial notes and make the submission look unfinished. Remove before submission; provide an anonymized artifact link. |
+
+The paper’s density of parallel constructions—“what X does and what it does not,” “one measurement…,” “two controls…,” “three omissions…”—also creates an LLM-generated stylistic impression. This does not imply that the content is machine-generated, but substantial copy-editing would make the prose more natural and scientific.
+
+---
+
+# Passages assigning outsized importance
+
+1. **Abstract/Introduction: “the paired extract-and-audit design outlasts [the corpus].”**  
+   This is not established. The audit design currently produces incompatible measurements and lacks human calibration. Rephrase as an intended reusable design.
+
+2. **Sections 1 and 4.1: “a resource whose unit is the document cannot represent it” and “document-level resources cannot serve” the query.**  
+   Too categorical. Document-level retrieval systems can answer mechanism questions through passage retrieval and synthesis, even if they do not store the mechanism as a first-class structured object. The defensible claim is that the proposed graph makes mechanisms directly queryable and comparable.
+
+3. **Section 4.1: a shared stage vocabulary is “the precondition” for cross-paper analysis.**  
+   It is one useful representation, not a necessary precondition. Cross-document comparison can be performed with embeddings, argument mining, or open relation extraction.
+
+4. **Section 2.7: extractor choice moves cost “more than any other decision in the pipeline.”**  
+   Only a limited set of model prices is compared, while audit coverage, similarity construction, retries, and path explosion are not comprehensively costed. Restrict the claim to the measured configurations.
+
+5. **Section 3.2: the second audit establishes “a direction and a floor.”**  
+   This is not supported because the population, document length, and serialized inputs differ. The result establishes instrument sensitivity, not a lower bound on omission.
+
+6. **Section 6.2: “The first extension is of scale rather than of method.”**  
+   This reverses the paper’s own evidence. Human-grounded fidelity evaluation and path-semantic validation should precede scaling to a larger corpus.
+
+7. **Conclusion: “The corpus answers mechanism-level queries that document-level resources cannot.”**  
+   Replace with the narrower claim that the corpus stores mechanism paths explicitly and returns them with source provenance.
+
+---
+
+# Non-load-bearing “sausage-making” to cut
+
+1. **The confounded before/after repair-grader experiment**  
+   - **Where:** Section 3.2, “One evaluation design that answers nothing”; related meta-grader score discussion in Sections 2.6 and B.  
+   - **Cut:** Delete the narrative entirely. Retain at most one limitation sentence saying the scores were excluded because the evaluation was unblinded.  
+   - **Why:** It contributes no usable result.
+
+2. **The prior internal substrate and stale-analysis history**  
+   - **Where:** Section 2.2, discussion of a “different substrate”; Section 2.7, numbers “carried over from an earlier internal pass”; Section 4 opening.  
+   - **Cut:** Remove from the main paper. Repository release notes can document version history.  
+   - **Why:** Readers need the final substrate and provenance of current results, not the project’s internal sequence of analyses.
+
+3. **The failed prior race-framing result**  
+   - **Where:** Section 4.5 and Appendix M.  
+   - **Cut:** Delete the section and appendix, or reduce to one general warning in the graph-artifact discussion.  
+   - **Why:** This is a postmortem of an unpublished internal result. It does not validate the proposed extraction pipeline or establish a substantive finding.
+
+4. **The pre-registered confusion-pair prediction that was “half right”**  
+   - **Where:** Section 3.1, second-model stage agreement discussion.  
+   - **Cut:** Remove the paragraph beginning “Where the two models disagree…” except for the theoretical-insight class metrics.  
+   - **Why:** The prediction is not central, and narrating which confusion pair was anticipated adds little.
+
+5. **Reference-list-only extraction arm**  
+   - **Where:** Section 3.1 and Table 16, arm G.  
+   - **Cut:** Delete.  
+   - **Why:** A bibliography is not a plausible competing input to the pipeline. The result is not informative beyond showing that the model sometimes refuses irrelevant input.
+
+6. **Flat-triple arm scored on chain yield**  
+   - **Where:** Section 3.1 and Table 16, arm D.  
+   - **Cut:** Delete unless it is evaluated on a task that flat triples can express.  
+   - **Why:** The paper notes that no chain is structurally expressible from this baseline; therefore failure on chain yield is predetermined by the representation.
+
+7. **“Two sevens are unrelated” and similar denominator narration**  
+   - **Where:** Section 3.2.  
+   - **Cut:** Delete and rewrite the statistics with unambiguous variable names.  
+   - **Why:** This is editing residue, not analysis.
+
+8. **Judge recovery of failed extractions**  
+   - **Where:** Section 2.2.2, 23/441 recovery result.  
+   - **Cut:** Move to appendix or repository documentation.  
+   - **Why:** Judge-based reconstruction of failed parser outputs is not part of the released pipeline or main evaluation.
+
+9. **Current-model repricing and hypothetical 10× extrapolation**  
+   - **Where:** Section 2.7.  
+   - **Cut:** Retain measured input tokens and estimated original cost; remove speculative repricing and tenfold-corpus discussion.  
+   - **Why:** Prices change rapidly and the extrapolation adds little scientific insight.
+
+Important failures that **should not** be cut include the shuffled-input result, the spurious Euclid chain, gate instability, and the merge-induced centrality artifact. These directly reveal limitations of the method or common downstream misinterpretations.
+
+---
+
+# Length triage: reducing the main paper from 15 to 10 pages
+
+The following list is ordered by estimated pages recovered per unit of score risk. “Move” assumes appendices are outside the hard 10-page main-body budget.
+
+| Order | Material | Action and reason | Estimated recovery | Running total | Score effect |
+|---:|---|---|---:|---:|---|
+| 1 | **Section 4.5, framing analysis that does not reproduce** | **Delete outright.** It is an internal-analysis postmortem rather than evidence for the extraction contribution. | 0.55 pages | 0.55 | None; Clarity may improve |
+| 2 | **Section 3.2 editorial/confounded material:** “Two sevens…,” repeated three-rate reconciliation, and the unblinded pre/post grader experiment | **Delete outright.** Keep a compact table defining each audit output and one limitation sentence. | 0.50 | 1.05 | None; Clarity may improve |
+| 3 | **Section 2.7 detailed compute/cost reconstruction and current-model repricing** | **Move to appendix.** Keep one main-text sentence with input tokens, model calls, and the caveat that output/reasoning cost was reconstructed. | 0.55 | 1.60 | None |
+| 4 | **Sections 2.2.2 and 2.3, plus detailed release plumbing in Section 2.7** | **Move to appendix.** Failure taxonomy, component counts, receipt-file architecture, retry behavior, and checkpoint sizes are reproducibility details rather than main findings. | 0.70 | 2.30 | None if the artifact and core configuration remain specified |
+| 5 | **Section 4.3 detailed clustering comparison** | **Move to appendix.** Keep one paragraph: node-level clusters are suitable for navigation, not inference; UMAP-space silhouettes are not comparable. | 0.55 | 2.85 | None |
+| 6 | **Section 4.4 detailed centrality case study, including Figure 4 and ANN candidate-recall discussion** | **Move Figure 4 and detailed four-condition analysis to appendix.** Keep one compact main-text table or paragraph stating the induced 90× hub and required control. | 0.90 | 3.75 | Minor; no numerical score change if the central result remains |
+| 7 | **Section 2.5 detailed collapse-loss narration** | **Move to appendix.** Keep the algorithm, 8,954→2,772 count, threshold sensitivity, 18% endpoint-pair loss, and explicit statement that “distinct argument” is unvalidated. | 0.50 | 4.25 | Minor; Quality would fall if the caveats were removed rather than moved |
+| 8 | **Section 3.1 detailed small-sample ablation and probe narrative** | **Move full arm-by-arm results, endpoint-recovery details, and confusion analysis to appendix.** In the main text retain: no-schema result, shuffled-input result, \(\kappa=0.84\), and one compact summary table. | 0.90 | **5.15** | Minor; no numerical score change if those four headline controls remain |
+
+This reaches the required five-page reduction without removing the core contribution.
+
+## Material I would refuse to move or cut
+
+1. **Pipeline/schema overview and Figure 1**  
+   - **Why:** Central to Originality and Clarity.  
+   - **Score at risk:** Originality 3→2 and Clarity 2→1 if the task representation becomes unclear.
+
+2. **Corpus and filtering funnel, preferably Figure 2 or an equivalent compact table**  
+   - **Why:** Readers must see the reduction from intake to the reporting set.  
+   - **Score at risk:** Quality and reproducibility.
+
+3. **The gate definitions and full gate-sensitivity result from Table 7**  
+   - **Why:** The selected set changes from 15.9% to 99.4% document yield; this is essential for interpreting every chain-level number.  
+   - **Score at risk:** Quality 2→1 if hidden.
+
+4. **The core audit results for both populations, together with the lack of human adjudication**  
+   - **Why:** This is the only direct fidelity evidence offered. It should be corrected, not omitted.  
+   - **Score at risk:** Quality 2→1.
+
+5. **Evidence of schema-induced fabrication and instability**  
+   - **Keep:** a concise shuffled-input result, the spurious-chain example or equivalent, and rerun gate instability.  
+   - **Why:** Removing these would materially misrepresent method reliability.  
+   - **Score at risk:** Quality and ethical assessment.
+
+6. **At least one provenance-bearing retrieval example, currently Table 1**  
+   - **Why:** This is the clearest demonstration of why the proposed representation could be useful.  
+   - **Score at risk:** Significance 3→2 if no concrete use case remains.
+
+7. **A concise related-work comparison with argument mining and document-level AI-safety resources**  
+   - **Why:** Necessary to establish the novelty of the task.  
+   - **Score at risk:** Originality 3→2.
+
+8. **Limitations, impact, licensing, misattribution risk, and correction/removal policy**  
+   - **Why:** The release can misattribute claims to identifiable authors, and the source licensing is heterogeneous.  
+   - **Score at risk:** Quality and overall acceptability.
+
+9. **A functioning anonymized artifact link and exact final release specification**  
+   - **Why:** The dataset and code are a primary contribution.  
+   - **Score at risk:** Overall 3→2 if unavailable.

--- a/paper/reviews_2026-08-17/gpt56sol_conference.meta.json
+++ b/paper/reviews_2026-08-17/gpt56sol_conference.meta.json
@@ -1,0 +1,11 @@
+{
+  "provider": "openai",
+  "model": "gpt-5.6-sol",
+  "mode": "conference",
+  "elapsed_sec": 264.0,
+  "response_chars": 34029,
+  "generated_utc": "2026-08-17T13:37:50+00:00",
+  "stop_reason": "completed",
+  "input_tokens": 46358,
+  "output_tokens": 14162
+}

--- a/paper/reviews_2026-08-17/gpt56sol_workshop.md
+++ b/paper/reviews_2026-08-17/gpt56sol_workshop.md
@@ -1,0 +1,420 @@
+## Summary
+
+This paper introduces a large-scale, schema-guided LLM pipeline for extracting risk-to-intervention argument chains from 11,779 documents in the Alignment Research Dataset. It produces a 200,525-node provenance-bearing graph and a filtered reporting set of 2,772 chains. A second-provider LLM audits samples of the extraction, while several ablations and graph-analysis case studies expose schema-completion, gating, merging, clustering, and centrality artifacts.
+
+The task is useful and the proposed artifact could be valuable. The paper is unusually candid about negative results and construction artifacts. However, the central scientific question—whether the extracted chains faithfully represent what the source documents argue—remains unresolved. Evaluation is entirely LLM-internal, the audit statistics are not conventional omission rates, the shipped and audited representations may differ, and paths are enumerated while ignoring edge direction and without enforcing stage monotonicity. Thus, the work is best viewed as an interesting, openly reported workshop-stage resource and pipeline, not yet a validated scientific information-extraction dataset.
+
+For a workshop, I lean **borderline accept**, conditional on making the artifact available and materially narrowing the claims.
+
+---
+
+# Strengths and Weaknesses
+
+## Strengths
+
+### Quality
+
+1. **The paper tackles an important and genuinely difficult extraction target.**  
+   Extracting a multi-stage, document-internal argument is more ambitious than metadata indexing, topical clustering, or isolated entity/relation extraction. Representing provenance-bearing paths from risks through rationales and mechanisms to interventions is potentially useful.
+
+2. **The engineering effort and scale are substantial.**  
+   Processing 11,779 heterogeneous full-text documents and producing a graph with 200,525 typed nodes is a meaningful resource contribution. The one-request-per-document architecture is operationally simple and plausibly scalable, although the actual call and cost claims need correction for retries and failures.
+
+3. **The authors report many important sensitivities rather than hiding them.**  
+   Particularly valuable observations include:
+   - chain yield changes from 15.9% to 99.4% under different LLM-assigned gates;
+   - the prompt strongly induces the canonical chain;
+   - sentence-shuffled and out-of-domain material can still yield apparently valid chains;
+   - node merging can manufacture a centrality super-hub;
+   - UMAP-space silhouette scores are not comparable to scores in the original embedding space;
+   - individual chain membership is unstable across repeated model runs.
+
+   These are useful warnings for researchers constructing LLM-generated knowledge graphs.
+
+4. **The provenance and release design are thoughtful in principle.**  
+   Retaining an unmerged graph, source URLs, node/edge attributes, raw enumerations, receipts, and scripts is preferable to releasing only a highly processed graph. The claim-to-script-to-receipt design would be a strong reproducibility feature if the artifact is actually available.
+
+5. **The paper is commendably frank about limitations and ethics.**  
+   It explicitly discusses misattribution, licensing uncertainty, venue skew, schema-induced completion, run-to-run instability, non-human validation, and the danger of treating graph-construction artifacts as findings about the field.
+
+### Clarity
+
+1. **The overall pipeline and data reductions are explained in considerable detail.**  
+   Figures 1–3, the enumerator constraints, the population table, and the gate sensitivity analysis help disentangle several otherwise confusable datasets.
+
+2. **The paper generally distinguishes extraction fidelity from truth of the source claim.**  
+   This is an important conceptual distinction: a faithful extraction of a weak argument is still a successful extraction.
+
+3. **The appendices contain unusually extensive implementation and prompt details.**  
+   An expert reader can understand the intended schema, model settings, path filters, and most downstream analyses.
+
+### Significance
+
+1. **A trustworthy mechanism-indexed safety corpus could be useful.**  
+   It could support direct retrieval, literature navigation, mapping of interventions to risks, and eventually evidence-gap analysis.
+
+2. **The negative methodological lessons generalize beyond AI safety.**  
+   The findings about schema completion, model-assigned gates, transitive deduplication, and graph metrics are relevant to LLM-generated scientific knowledge graphs more broadly.
+
+3. **The work is appropriate for workshop discussion.**  
+   It is early, empirical, and openly reports unresolved failures. That is a reasonable workshop contribution even though the resource is not yet sufficiently validated for strong substantive conclusions.
+
+### Originality
+
+1. **The task formulation and resulting dataset are relatively novel.**  
+   The method itself—schema prompting, embeddings, graph ingestion, and LLM auditing—is not algorithmically novel, but the risk-to-intervention mechanism-chain representation is a useful domain-specific synthesis.
+
+2. **The paper offers original empirical observations about its own construction pipeline.**  
+   The merge-manufactured centrality hub and the strong dependence on LLM-assigned gates are more original and convincing than several of the proposed downstream literature findings.
+
+---
+
+## Weaknesses
+
+### Quality
+
+1. **There is no human-anchored fidelity evaluation. This is the central limitation.**  
+   The extractor, judge, meta-graders, maturity labels, confidence labels, and stage labels are all produced or assessed by LLMs. Cross-provider agreement does not establish correctness because both models use the same definitions and similar linguistic priors.
+
+   The paper therefore does not establish:
+   - node precision or recall against source documents;
+   - edge precision or recall;
+   - whether a complete path is a coherent argument actually made by the source;
+   - calibration of edge confidence;
+   - calibration of intervention maturity;
+   - whether the 70% path-collapse heuristic preserves distinct arguments.
+
+   The Euclid failure case is especially consequential: a chain can pass all gates while inventing a safety framing. This demonstrates that the current gates are not reliable fidelity filters.
+
+2. **The extraction prompt conflicts with the stated objective of recording what a paper argues.**  
+   The prompt says to use “moderate inference” when the source lacks a required flow and to infer an intervention when none is explicit. It also requires every path to begin at a risk and end at an intervention. This encourages completion of the schema rather than extraction of source-supported arguments.
+
+   The confidence gate is not a sufficient remedy because confidence is assigned by the same model that invented the chain. The paper’s own failure case shows that unsupported framing can receive confidence and maturity values high enough to pass.
+
+3. **The path definition does not guarantee a semantically valid mechanism chain.**  
+   Enumeration ignores stored edge direction and allows all relation types. It apparently does not require stage order to be monotonic. Consequently, a path can:
+   - traverse a causal relation backward;
+   - visit stages in a non-canonical order;
+   - combine relations that do not jointly express a risk-reduction mechanism;
+   - reach an intervention through graph connectivity rather than an argumentatively coherent chain.
+
+   Reporting that 87.4% of paths contain all five stage labels does not answer this problem. A path can contain all labels while being directionally or logically incoherent.
+
+4. **The “omission rates” are not well-defined omission rates.**  
+   For example, 302 missing relationships divided by 1,667 graph edges gives 18.1%, but the 302 items come from a separate “expected relationships” list. A recall-like denominator would instead involve the expected items, not all extracted graph edges. The expected-list statuses sum to 776, although the paper says there are 777 rows:
+   \[
+   328 + 146 + 302 = 776.
+   \]
+   Similarly, 557 proposed nodes divided by 2,110 existing nodes is a relative addition ratio, not the fraction of relevant nodes omitted.
+
+   Table 15’s statement that all three measurements are “upper bounds on omission” is also unjustified. An unadjudicated LLM can both invent missing items and fail to identify actual omissions; these quantities are neither guaranteed upper nor lower bounds.
+
+5. **The comparison between the two audit samples is confounded, yet the paper draws a directional conclusion.**  
+   The second audit uses longer documents and graph-reconstructed extractions lacking fields present in the first audit. The paper acknowledges this but then states that omission in the analyzed population is “at least as high” and calls the result a “direction and a floor.” That conclusion does not follow from the design. The difference could arise from representation, document length, population, model instability, or their interaction.
+
+6. **It is unclear whether the audited artifact is the shipped artifact.**  
+   Section N says the judge audited pre-ingestion extraction JSON containing referential-integrity and orphan issues, while those defects do not survive into the released graph. The judge’s re-serialized graphs also have substantially fewer edges than the released graph for the same documents. This conflicts with the claim that “the stage we audit is the stage we ship.” The mapping from audited JSON to final graph needs to be explicit, and ideally the final released representation should itself be audited.
+
+7. **The 70% containment collapse is insufficiently validated.**  
+   It removes:
+   - 18.0% of distinct raw risk-to-intervention pairs;
+   - 6.1% of enumerated nodes entirely;
+   - many paths reaching interventions absent from their retained container.
+
+   The authors correctly acknowledge that it is unknown whether these are duplicates or distinct arguments. Given that the 2,772 chains are the main reporting unit, this heuristic needs at least a human annotation study or a stronger sensitivity analysis.
+
+8. **Several baselines are weak or structurally unfair.**
+   - The flat-triple baseline cannot express the target chain by construction.
+   - Abstract-only and non-reasoning comparisons use very small, selected samples.
+   - The baseline documents are often conditioned on yielding a chain under the shipped system.
+   - Endpoint recovery against an earlier stochastic run of the same system is not a gold-standard fidelity metric.
+
+   These experiments are informative diagnostics, but they do not establish superiority over a competing extraction or retrieval system.
+
+9. **The compute accounting is presented too strongly.**  
+   The abstract calls 122.4M input tokens “measured,” but the logs did not survive and the value is reconstructed for successful documents under one nominal request each. Retries and failed records may have generated additional calls and tokens. Likewise, visible output is extrapolated from one surviving response, and the reasoning-token band is assumed. This should be called a reconstructed nominal estimate, not a measured bill.
+
+10. **The submission is incomplete as presented.**  
+    The release URL is a placeholder, and the acknowledgments and AI-assistance statement contain unresolved GAP markers. An anonymous author placeholder is understandable during review, but an unavailable artifact prevents verification of the main resource contribution.
+
+### Clarity
+
+1. **The main paper is far too long and repetitive.**  
+   It repeatedly restates the same distinctions:
+   - released graph versus analyzed chain set;
+   - structural completeness versus fidelity;
+   - node versus edge omission instruments;
+   - gate-selected results versus claims about the literature;
+   - merged versus unmerged graph artifacts.
+
+   These are important once, but the repetition obscures the central result.
+
+2. **The prose often uses rhetorical, slogan-like constructions rather than direct scientific exposition.**  
+   Examples include “We report them all and reconcile none,” “One evaluation design that answers nothing,” and “Two sevens in this subsection are unrelated.” These may be memorable, but they make the paper read like an analysis diary rather than a finished scientific report.
+
+3. **Important results are interleaved with project history and failed internal analyses.**  
+   References to “earlier drafts,” “an earlier internal pass,” grader sessions that drifted, and prior non-reproducing findings make it difficult to identify the final experimental design.
+
+4. **Some terminology overstates what is measured.**  
+   “High-confidence,” “mature,” “omission rate,” and “complete mechanism” are stronger than the underlying LLM-assigned or structurally defined quantities warrant.
+
+### Significance
+
+1. **Utility depends strongly on fidelity, which is currently unknown.**  
+   A mechanism-indexed graph can be valuable only if users can trust that a source actually makes the represented argument. Provenance helps users check claims, but it does not substitute for dataset-level quality measurement.
+
+2. **The corpus stops at 2023.**  
+   This substantially limits immediate usefulness for a fast-moving AI-safety literature. The pipeline may be more valuable than the current snapshot.
+
+3. **The retrieval demonstration lacks an evaluation.**  
+   Two worked examples show addressability, not retrieval quality. There is no query set, relevance judgment, user study, or comparison against full-text semantic retrieval/RAG.
+
+4. **Many graph-level use cases are shown to be unreliable.**  
+   This is a useful methodological lesson, but it narrows the demonstrated practical impact of the released graph.
+
+### Originality
+
+1. **The pipeline is mainly a composition of existing techniques.**  
+   The novelty lies in the schema, scale, artifact, and diagnostics—not in a new extraction, auditing, or graph-learning method.
+
+2. **The paper needs a stronger comparison to modern LLM information-extraction and knowledge-graph construction work.**  
+   The related-work section covers scientific IE, argument mining, and GraphRAG, but the empirical comparison is almost entirely against internally designed degraded variants rather than external extraction systems or benchmarks.
+
+---
+
+# Scores
+
+| Dimension | Score | Rationale |
+|---|---:|---|
+| **Quality** | **2 / 4 — Fair** | Large and carefully documented pipeline, but central source fidelity is not human-validated; path semantics and audit metrics have material validity problems. |
+| **Clarity** | **3 / 4 — Good** | Well organized and unusually explicit, but substantially overlong, repetitive, and occasionally confusing due to multiple incompatible audit instruments. |
+| **Significance** | **3 / 4 — Good** | Potentially useful workshop resource and broadly relevant methodological cautions, though present utility is limited by unknown fidelity and a pre-2024 corpus. |
+| **Originality** | **3 / 4 — Good** | Novel task/schema/resource and useful artifact analyses, despite relying mainly on standard LLM extraction and graph-processing components. |
+
+## Overall
+
+**4 / 6 — Borderline Accept**
+
+For a workshop, the reasons to accept narrowly outweigh the reasons to reject: the task and artifact are interesting, the scale is meaningful, and the authors report failures with unusual honesty. The acceptance case depends on presenting this as an early, unvalidated resource rather than a measured map of the safety literature.
+
+I would increase this to **5 (Accept)** if the authors provide an accessible artifact and a credible blinded human fidelity evaluation showing useful node-, edge-, and path-level precision. I would decrease it to **3 (Borderline Reject)** if the artifact remains unavailable or if the audited representation is materially different from the shipped graph without a final-graph audit.
+
+## Confidence
+
+**4 / 5**
+
+I am confident in the assessment of the experimental design and evaluation limitations. Some uncertainty remains about the exact contents of the unavailable release and about conventions in this domain-specific literature.
+
+---
+
+# Questions and Actionable Suggestions
+
+1. **Can the authors provide human-anchored node-, edge-, and path-level evaluation?**  
+   Please have at least two blinded human annotators inspect a stratified sample of source documents and report:
+   - precision of extracted nodes and edges;
+   - recall against independently annotated source claims;
+   - whether each retained path is a coherent argument made by the source;
+   - agreement and adjudication;
+   - accuracy/calibration of edge confidence and intervention maturity.
+
+   Sampling should include chain-yielding and non-chain-yielding documents, major source types, and document-length strata. Actual human results showing useful fidelity would increase my Quality score from 2 to 3 and likely the Overall score from 4 to 5. Merely promising this as future work would not.
+
+2. **How many reported chains are directionally and logically valid?**  
+   Please quantify:
+   - stage-order violations;
+   - edges traversed against their semantically intended direction;
+   - paths using each relation type in each direction;
+   - paths whose intervention is connected through a structurally valid but argumentatively incoherent route.
+
+   A useful comparison would be directed versus undirected traversal, and traversal with versus without monotonic stage-order constraints. If a substantial fraction of the 2,772 chains are invalid under these checks, the paper should stop calling them mechanism chains and my Overall score would decrease.
+
+3. **Please redefine and rerun the omission analysis.**  
+   The current ratios are not standard omission rates. Please:
+   - audit exactly the final released representation;
+   - use the same schema and fields for both populations;
+   - give the judge explicit node- and edge-repair slots;
+   - define precision/recall denominators before evaluation;
+   - report confidence intervals;
+   - resolve the 777-versus-776 arithmetic discrepancy;
+   - avoid describing unadjudicated LLM findings as upper bounds.
+
+   At minimum, rename the current quantities as “judge-proposed additions relative to extracted size” and “judge-listed missing relationships relative to extracted edge count.”
+
+4. **Can the 70% path-collapse heuristic be validated or replaced?**  
+   Please annotate a sample of retained/dropped path pairs as:
+   - duplicate rendering of the same argument;
+   - granularity variant;
+   - distinct argument;
+   - invalid path.
+
+   Alternatively, use paper-level sets of risk–intervention pairs as the primary reporting unit and retain all paths as evidence. The present loss of 18% of raw endpoint pairs is too large to treat as incidental.
+
+5. **Will the complete anonymous artifact be available during review?**  
+   The release URL is currently a GAP marker. Please provide the graph dump, sample IDs, extraction JSON, prompts, model identifiers, path files, receipts, and scripts through an anonymous link. Also distinguish nominal requests from API attempts and reconstruct cost over both successful and failed records. If the artifact cannot be inspected, the paper’s main resource and reproducibility claims are not verifiable.
+
+---
+
+# Limitations
+
+yes
+
+---
+
+# Additional Writing and Presentation Flags
+
+## 1. Unscientific, unacademic, overly informal, or LLM-like writing
+
+The paper is generally grammatical, but it repeatedly uses an LLM-like cadence of emphatic fragments, binary contrasts, and self-commentary. This contributes heavily to the excessive length.
+
+1. **Abstract:**  
+   > “We report them all and reconcile none.”
+
+   This is rhetorically dramatic but scientifically unhelpful. Replace it with a direct statement that the instruments are not comparable and no aggregate fidelity estimate is claimed.
+
+2. **Section 3.2:**  
+   > “One evaluation design that answers nothing.”
+
+   Too informal and absolute. Prefer: “The pre/post repair comparison is confounded and is therefore excluded from the analysis.”
+
+3. **Section 3.2:**  
+   > “Two sevens in this subsection are unrelated.”
+
+   This is editorial housekeeping that should not appear in a final paper. Rename the quantities or rewrite the paragraph so no disambiguation is necessary.
+
+4. **Section 3.2:**  
+   > “Three omission measurements, spanning a factor of thirty, and what separates them.”
+
+   This reads like a blog heading. Use a conventional heading such as “Comparison of audit instruments.”
+
+5. **Section 3.1:**  
+   > “The categories are ones the model reaches for unprompted; the seven-node chain that traverses all five is what the prompt supplies.”
+
+   “Reaches for” anthropomorphizes the model. State instead that free-form labels can be mapped to the proposed categories, while full-chain completion depends strongly on the prompt.
+
+6. **Section 4.4:**  
+   > “what follows measures what the step costs a reader who does.”
+
+   Awkward and conversational. Use: “We therefore evaluate the downstream effect of applying this merge.”
+
+7. **Section 4.5 and elsewhere:**  
+   Frequent references to “an earlier pass,” “earlier drafts,” and findings that “did not survive” make the paper read as a project log. The final paper should report the final protocol and results; development history belongs in version control, not the scientific narrative.
+
+8. **Section 6.3:**  
+   > “The extension we would prioritize…”
+
+   This is unnecessarily first-person and subjective. Use a concise future-work statement.
+
+9. **Unresolved placeholders:**  
+   The release URL, compute acknowledgment, contribution statement, and AI-assistance scope remain marked as GAPs. These make the submission visibly unfinished. The author-list placeholder may be appropriate for anonymization, but the artifact and substantive declarations must be finalized.
+
+10. **General style:**  
+    The repeated pattern “X, and what it does/does not mean,” “the control each one needs,” “not X but Y,” and “two things follow” is overused. It resembles generated rhetorical scaffolding and should be replaced with shorter declarative prose.
+
+## 2. Outsized-importance language
+
+There are few literal uses of “critical” or “essential,” but several passages serve the same rhetorical function.
+
+1. **Introduction:**  
+   > “the paired extract-and-audit design outlasts it”
+
+   This overstates a routine cross-provider LLM audit that is not human-calibrated and produces incompatible measurements. Suggested revision: “The pipeline may be reusable across newer corpora, subject to domain- and model-specific validation.”
+
+2. **Sections 1 and 4.1:**  
+   > “a resource whose unit is the document cannot represent it, query it, or compare it across papers”  
+   > “The dataset supports a query that document-level resources cannot serve”
+
+   Too absolute. Full-text retrieval and RAG systems can answer such questions, although they do not natively expose a structured path. Suggested revision: “Document-level indexes do not directly expose this relation as a structured, comparable field.”
+
+3. **Section 3.2:**  
+   > “What the run establishes is a direction and a floor”
+
+   The confounded comparison establishes neither. Delete this conclusion.
+
+4. **Section 4.2:**  
+   > “The skew is a four-bucket call with a very large margin and would survive a substantial per-item error rate”
+
+   This is unsupported without a quantified sensitivity analysis. Delete or provide an explicit worst-case calculation.
+
+5. **Section 4.4:**  
+   > “Centrality on this graph requires the un-merged substrate and the exclusion of within-category similarity edges, in that order”
+
+   The evidence supports this recommendation for the tested merge and eigenvector-centrality configuration, not as a universal requirement. Scope the statement accordingly.
+
+6. **Conclusion:**  
+   > “The corpus answers mechanism-level queries that document-level resources cannot.”
+
+   Again, use “supports direct structured mechanism-level queries not natively represented by document-level indexes.”
+
+---
+
+# 3. Non-load-bearing “sausage-making” to cut
+
+1. **Confounded pre/post repair scoring — Section 3.2, “One evaluation design that answers nothing.”**  
+   **Cut outright.** The paper draws no result from it, and the experiment was knowingly unblinded and uncontrolled. One sentence in the audit limitations is enough: “We exclude unblinded pre/post repair scores.”
+
+2. **Failed race-framing result — Section 4.5 and Appendix M.**  
+   **Cut the main-body section outright.** It reports an earlier 88%/44-fold finding that does not reproduce, followed by a generic lesson about selected heads. This does not validate the extraction pipeline or establish a substantive corpus result. If retained at all, one sentence can appear in an appendix on analysis pitfalls.
+
+3. **History of the earlier internal substrate — Section 2.2 final paragraph, Section 2.7 exceptions, and the setup to Sections 4.3–4.5.**  
+   **Cut references to the earlier pass.** Report only the released substrate and the final controlled experiments. The internal graph’s node count and previous similarity density are development history.
+
+4. **Uninterpretable meta-grader pre/post scores and session mechanics — Sections 2.6, 2.7, 3.2, and Appendix B.**  
+   **Cut the scoring component unless it is rerun under a standardized protocol.** Interactive sessions with schema drift and denominators of 95/95/13 do not support a scientific result. If the 43-document taxonomy is retained, state its limited provenance once.
+
+5. **Judge recovery of failed extractions — Section 2.2.2.**  
+   **Cut the 441-document/23-recovery experiment.** It is peripheral to the released successful-extraction graph and does not inform the quality of the reported chains. Retain only the extraction-failure counts and causes.
+
+6. **Detailed rejected merge configurations and ANN implementation history in the main text — Section 4.4.**  
+   **Move to the appendix.** The central insight—that transitive merging can manufacture a hub—is useful. The exact rejected configurations, candidate counts, and engineering history are not needed in the main narrative.
+
+7. **Detailed catalog of clustering attempts — Section 4.3.**  
+   **Move to the appendix, not delete.** The UMAP silhouette pitfall is useful, but the list of configurations “tried and abandoned” is not central.
+
+I would **not** classify the sentence-shuffling control or the Euclid failure case as sausage-making. They are load-bearing evidence that structural validity and gate passage do not imply source fidelity.
+
+---
+
+# 4. Length triage: reducing the main body from approximately 15 to 10 pages
+
+Estimates below are approximate and assume that concise one-paragraph summaries remain in the main paper where necessary. The list is ordered by pages recovered per unit of score risk.
+
+| Rank | Material and location | Action and rationale | Estimated recovery | Running total | Effect on scores |
+|---:|---|---|---:|---:|---|
+| 1 | Repetitive limitations, **Section 6.1** | **Compress heavily** to approximately 0.7–0.8 pages. Move detailed run-to-run numbers, model comparisons, source-type tables, and gate-specific repetitions to the existing appendices. Keep the lack of human validation, gate instability, venue skew, collapse loss, and corpus cutoff. | **1.1 pages** | **1.1** | None; likely improves Clarity |
+| 2 | Failed framing analysis, **Section 4.5** | **Delete outright.** The non-reproducing race-framing result is not part of the final contribution. Retain at most one general warning about selection-conditioned statistics. | **0.65 pages** | **1.75** | None |
+| 3 | Audit editorial material, **Section 3.2**: “two sevens,” failed pre/post design, repeated three-way reconciliation, schema-mismatch detail | **Delete the failed design and compress/move diagnostic detail to the appendix.** Keep one compact table or paragraph reporting both audit populations, the incompatible instruments, and the absence of human adjudication. | **0.65 pages** | **2.40** | None |
+| 4 | Detailed cost reconstruction and model repricing, **Section 2.7** | **Move to appendix.** Keep one sentence with nominal input scale and an explicitly qualified cost range. Current derivation is too uncertain for main-body emphasis. | **0.45 pages** | **2.85** | None |
+| 5 | Detailed graph-analysis case studies, **Sections 4.3–4.4 and Figure 4** | **Move details and Figure 4 to appendix.** Retain approximately half a page summarizing two reusable cautions: UMAP-space evaluation inflation and transitive-merge centrality artifacts. These are useful but secondary to the extraction resource. | **1.45 pages** | **4.30** | Minor risk only; no numerical score drop if preserved in appendix |
+| 6 | Auxiliary small-sample experiments, **Section 3.1**: three simpler pipelines, probe decomposition, second-annotator confusion details | **Move to appendix.** Keep one paragraph with the key conclusions and numbers: prompt-induced chain completion, shuffled-text chains, and cross-provider stage agreement. Keep gate sensitivity in the main body. | **0.9 pages** | **5.20** | Minor; no numerical score drop if preserved in appendix |
+| 7 | Detailed drop-versus-container diagnostics, **Section 2.5** | **Move to appendix as a buffer.** Keep the collapse rule and the headline losses—18% endpoint-pair loss and 6.1% node loss—in the main text. | **0.3 pages** | **5.50** | None |
+
+This reaches the five-page target without removing the central method or its most important limitations.
+
+## Material I would refuse to move or cut
+
+1. **The task definition and canonical schema, including a compact Figure 1.**  
+   The **Originality** and **Clarity** scores depend on understanding what is being extracted.
+
+2. **Corpus funnel and released artifact definition, including the distinction between 200,525 nodes, 8,954 raw paths, and 2,772 retained chains.**  
+   The **Quality** and **reproducibility** assessment depends on this.
+
+3. **Model configuration and prompt-induced inference policy.**  
+   The instruction to infer missing stages and interventions is central to interpreting fidelity. Removing it would materially reduce **Quality** and **Clarity**.
+
+4. **Path constraints, especially ignored edge direction, stopping rules, maturity/confidence gates, and the 70% collapse.**  
+   These determine what a “chain” means. The **Quality** score depends directly on them.
+
+5. **Gate sensitivity headline results.**  
+   The movement from 15.9% to 99.4% document yield is one of the paper’s most important and credible findings. Cutting it would reduce **Quality**.
+
+6. **A concise core audit section covering both populations, the incompatible results, and absence of human adjudication.**  
+   The paper’s acceptance case depends heavily on its honesty about unknown fidelity. Removing these caveats would reduce **Quality** and could lower the Overall score.
+
+7. **At least one explicit schema-invention control or failure case.**  
+   The shuffled-source result or Euclid example must remain visible, even if the full details are in an appendix. The **Quality** assessment depends on acknowledging that gate-passing chains can be spurious.
+
+8. **A compact related-work section.**  
+   The **Originality** score depends on distinguishing this task from argument mining, scientific IE, knowledge-graph construction, and document-level literature maps.
+
+9. **Artifact availability, reproducibility statement, impact statement, licensing discussion, and AI-assistance disclosure.**  
+   The **Quality**, ethics, and Overall scores depend on these. They should be finalized and shortened, not removed.

--- a/paper/reviews_2026-08-17/gpt56sol_workshop.meta.json
+++ b/paper/reviews_2026-08-17/gpt56sol_workshop.meta.json
@@ -1,0 +1,11 @@
+{
+  "provider": "openai",
+  "model": "gpt-5.6-sol",
+  "mode": "workshop",
+  "elapsed_sec": 279.9,
+  "response_chars": 31848,
+  "generated_utc": "2026-08-17T13:38:05+00:00",
+  "stop_reason": "completed",
+  "input_tokens": 46402,
+  "output_tokens": 15243
+}

--- a/paper/reviews_2026-08-17/opus5_conference.md
+++ b/paper/reviews_2026-08-17/opus5_conference.md
@@ -1,0 +1,128 @@
+## Summary
+
+The paper contributes (i) a two-stage LLM pipeline that extracts, per document, a typed "mechanism chain" running from a named AI-safety risk through five prescribed reasoning stages to a proposed intervention, and (ii) the artifact this produces over the Alignment Research Dataset: 200,525 typed nodes over 11,779 documents, from which 2,772 gate-selected chains over 1,868 documents are enumerated. A judge model from a second provider audits 100 documents (twice, on two populations), three meta-graders profile the judge's findings, and Section 4 demonstrates five use cases, three of which the authors show are distorted by construction artifacts of their own pipeline. Extensive ablations (stage-name removal, shuffled sentences, abstract-only, non-reasoning model, flat triples, re-run stability) and a gate-sensitivity grid are reported.
+
+---
+
+## Strengths
+
+**Honesty and self-auditing far above the norm for a resource paper.** The gate-sensitivity grid (Table 7) is exactly the right control for a chain set selected by two unvalidated LLM attributes, and it is reported rather than buried: corpus yield moves 15.9% → 99.4% across gate settings while five-stage completeness moves only eight points. Table 6 (twelve populations, what each licenses) and Table 15 (three omission measurements against their own denominators) are unusually disciplined. Section P (the Euclid-primes chain that passes every filter) is a genuinely load-bearing negative example, and Section 4.4's demonstration that the "most central risks are existential" result is manufactured by a transitive-closure merge is a real methodological contribution to anyone building graphs of this shape.
+
+**The right ablation exists.** Arm E (stage names stripped) is the control that matters: chain yield falls 100% → 36.7% and all-five completeness to 0%, while the model unprompted invents 144 labels of which 138 map onto the five stages. That separates "the vocabulary is latent in the model" from "the chain is supplied by the prompt," and the paper draws the correct, deflationary conclusion from it.
+
+**Reproducibility discipline.** Receipt files, a claim-to-script-to-receipt map, the released enumerator reproducing the shipped 8,954/2,772 sets exactly, and the honest marking of the two numbers that are *not* re-derivable.
+
+**The κ = 0.84 second-annotator arm** is the correct answer to the circularity of the 98.8% self-consistency probe, and the paper says so itself.
+
+## Weaknesses
+
+**1. There is no human ground truth anywhere, and the paper's central quality claim consequently has no anchor.** Validation is LLM-internal end to end, as the authors state. The consequence is not just imprecision: the four omission estimates (0.6%, 18.1%, 26.4%, 28.8%) span a factor of ~45, and the paper explicitly declines to reconcile them ("We report them all and reconcile none"). Candour is not a substitute for measurement. A single author-annotated sample of 20–30 documents would arbitrate the spread and would cost a day; its absence is the main reason I cannot rate quality higher. The most decision-relevant missing number is trivially cheap: what fraction of a random 50 released chains are *spurious in the Section P sense*? Without it, a reader cannot tell whether the corpus is 5% Euclid or 40% Euclid, and Section 3.1's 30.0% chain yield from sentence-shuffled sources is worryingly suggestive.
+
+**2. The utility claim is asserted, not tested.** The motivating question is "is a mechanism-indexed corpus better than a document index for answering mechanism queries?" Section 4.1 answers it with two hand-picked chains and no query set, no relevance judgements, and no comparison against embedding search over abstracts — the authors concede this. Section 5's comparison against the AI Safety Graph (325 risk–intervention pairs vs. 79 topic labels) is the most convincing utility evidence in the paper and is one paragraph in Related Work; it is worth more than Section 4.1.
+
+**3. The artifact is not actually available.** The submission carries live placeholders: `[GAP: release URL — GitHub / Google Drive location to be inserted]`, plus GAP boxes in the acknowledgments and the AI-assistance statement. For a paper whose stated contribution is "the pipeline and the corpus," an unresolvable release pointer is disqualifying in its current form. This is fixable in rebuttal and I would move on it.
+
+**4. Two of the five use cases are essentially post-hoc corrections of the authors' own earlier internal analysis pass**, run on a different substrate that is not released (the "merged 200,061-node graph with a similarity layer 8.5× sparser"). Section 4.5's race-framing non-reproduction (88% → 2.6%; 44-fold → 2.0-fold) audits a finding no reader has seen, and its "Control" is generic advice about selection-conditioned statistics. This is project history, not a result.
+
+**5. Scope and dating.** ARD stops at 2023 (median 2021), so the corpus contains no frontier-era discourse — acknowledged, but it substantially discounts significance for the coordination use case the Outlook proposes. The gate skew (arXiv 40.5% yield vs. LessWrong 6.9%) means the analysed unit under-represents the forum discourse that is a large fraction of this literature.
+
+**6. Run-to-run instability at the reporting unit.** Node identity survives re-extraction 46.5% of the time at cosine 0.80, and membership of the chain set turns on a maturity label that flips for 7 of 18 re-run documents. The authors report this squarely, but it means the released 2,772-chain set is one sample from a high-variance process, and no analysis in the paper is averaged over runs.
+
+**7. Length and clarity.** The main body runs ~15 pages for a contribution that fits in 8–9. Structural completeness, the reader-instruction preamble, and the LLM-internal-validation caveat are each restated three or four times (Introduction, 3.1, 3.2, 4.2, 6.1, 6.3). Twelve populations with non-nested relations is genuinely hard to hold in mind, and the paper compensates with meta-commentary rather than compression.
+
+---
+
+## Flagged: writing style
+
+The prose has a distinctive aphoristic-declarative register that reads as machine-drafted and, more importantly, substitutes rhetoric for reporting. Instances:
+
+- Abstract: "We report them all and reconcile none." Also "The stage we audit is the stage we ship."
+- §1: "Two things follow for how the rest of this paper should be read, and we state them here." Reader-instruction, not exposition.
+- §2.3: "A corpus of $N$ short chains is exactly $N$ components until something links them." §2.4: "That expansion is the purpose of the layer and also its hazard."
+- §3.1: "Where the two models disagree is more informative than that they mostly do not."
+- §3.2 heading: "**One evaluation design that answers nothing.**" And "**Two sevens in this subsection are unrelated.**" — the latter is chatty and belongs, if anywhere, in a footnote.
+- §4.5 / §4: "**Some statistics are true by design.**"
+- §6.1: "Counts do: … Node identity does not: … The gate does not either:" — telegraphic; "Read those rows for portability rather than for capability"; "the paths explode."
+- Section headings written as full editorial claims throughout ("A second run on the analysed population finds more, not less") — defensible in isolation, but combined with the above it reads as a manuscript drafted to a rhetorical template.
+- Four live `[GAP: …]` placeholders in the body, acknowledgments, and AI-assistance statement.
+
+Recommendation: convert claim-headings to noun phrases, delete all first-person meta-instruction to the reader, and state each caveat once in Limitations.
+
+## Flagged: outsized importance to non-load-bearing material
+
+- §2.7: "the choice of extractor moves the bill by about a factor of five — **more than any other decision in the pipeline**." A cost-repricing exercise on hypothetical models is elevated above the schema and the gates, which actually determine the output.
+- §1: "This work adds the layer beneath that stack"; "the paired extract-and-audit design outlasts it." Durability claims with no evidence.
+- §4.1: "which is **the precondition for** the cross-paper analysis of Section 6.2" — Section 6.2 explicitly does not perform that analysis.
+- §2.5: "The objective of the step is therefore stated in terms of the reporting unit we want" — an elaborate normative framing for a greedy 70%-containment de-duplication heuristic.
+- §2.7: the receipt/claim-map apparatus is a virtue but consumes half a column; one sentence plus a README pointer suffices.
+- §6.3 lists the 90× centrality hub among the headline results; it is a caveat about a step the authors did not apply.
+
+## Flagged: sausage-making with no load-bearing insight
+
+Named, with the cut:
+
+1. **§3.2 "One evaluation design that answers nothing"** (pre/post repair scoring, unblinded, no null-repair arm) — plus the Table 6 row "Scored before/after repairs 95, 95, 13" and Appendix N's "Grader agreement" paragraph. **Cut all of it**; retain one sentence in Limitations ("we did not evaluate whether the judge's repairs help").
+2. **§4.5 framing analysis** (race-framing 88% → 2.6%, 44× → 2.0×, and the 51 → 2 disconnection figure) — audits an unreleased internal substrate. **Cut**; retain Appendix M and one sentence under §4.4's Control.
+3. **§2.2's "An earlier internal pass … 200,061-node graph, similarity layer 8.5× sparser."** Project history. **Delete.**
+4. **§2.5 "What the step drops, measured against what displaced it"** (chords vs. distinct, 6.1% node loss, 18.0% of pairs) — appendix material; the main text needs only "the collapse is not lossless; see Appendix."
+5. **Appendix B / §2.7 meta-grader operational narrative** ("interactive agent session pointed at a folder… the output schema drifted within a run… Don't make a python script"). This explains why denominators differ but reads as an incident report. **Compress to two sentences**; the "Don't ask for permission, process all files" prompt text can go.
+6. **§2.7 "Two large intermediate checkpoints (~3.2 GB) are rebuildable"** — README content. **Delete.**
+7. **Appendix F: "7 chains (0.3%), from 3 documents, originate from Google Docs."** Trivia. **Delete.**
+8. **§3.2 "Three omission measurements, spanning a factor of thirty, and what separates them"** duplicates Table 15 verbatim in prose. **Delete the prose, keep Table 15.**
+
+---
+
+## Length triage: 15 → 10 pages
+
+Ordered by pages recovered per unit of score risk; running total in bold.
+
+| # | Item (location) | Action | Pages | Score effect |
+|---|---|---|---|---|
+| 1 | §4.5 framing analysis + its Control (¶¶ on p.11–12) | **Delete**; Appendix M already holds the classifier validation. It re-audits an unreleased substrate and its lesson is generic. | 0.5 | none — **0.5** |
+| 2 | §1 "Two things follow for how the rest of this paper should be read" + §1.1 bullet list (duplicates the abstract) | **Delete outright.** Pure signposting. | 0.5 | none — **1.0** |
+| 3 | §3.2 pre/post-repair design ¶ + "Two sevens" ¶ + "Three omission measurements" ¶ | **Delete** (Table 15 carries the content; one Limitations sentence for the confounded design). | 0.45 | none — **1.45** |
+| 4 | §2.5 "What the step drops" (chords, 6.1%, 18.0%, threshold sweep) | **Move to appendix**; it is a sensitivity check, not a claim. | 0.4 | none — **1.85** |
+| 5 | §3.1 probe paragraphs beyond the headline (TF-IDF decomposition, centroid margins, error breakdown) | **Move to Appendix G** (already there in part); keep "a probe recovers stage at 98.8% vs 20.0% chance, largely explained by the prescribed name template." | 0.35 | none — **2.2** |
+| 6 | §3.1 second-annotator per-stage disagreement analysis (registered-prediction discussion, 26/84, 19, 7) | **Move to Appendix** with Table 11; keep κ = 0.838 and "theoretical insight is the weakest stage." | 0.4 | none — **2.6** |
+| 7 | §4.3 clustering (silhouette 0.014 / 0.281 / 0.004 argument) | **Compress to four sentences** + pointer to Appendix J/K. The negative result is worth keeping; the space is not. | 0.4 | none — **3.0** |
+| 8 | §2.7 token-bill reconstruction and current-model repricing band | **Move to appendix**; keep "122.4M input tokens, USD 32–118 per 1,000 documents." | 0.5 | minor — **3.5** |
+| 9 | §6.1 Limitations (currently ~2.2 pp, most of it restating §§2.4–3.2) | **Compress to ~0.8 p**, one paragraph per distinct limitation, no re-derivation of numbers already in tables. | 1.2 | minor (candour is a strength; redundancy is not) — **4.7** |
+| 10 | §6.2 Outlook | **Compress to 0.2 p**; three named directions, no elaboration. | 0.3 | none — **5.0 ← five pages reached** |
+| 11 | §5 GraphRAG and hypothesis-generation paragraphs | Compress by half; the AI Safety Graph comparison stays and should be *lengthened* relative to the rest. | 0.35 | none — 5.35 |
+| 12 | Table 1, second retrieval example (Ngo et al.) | Move to appendix; one worked query demonstrates the point. | 0.25 | minor — 5.6 |
+| 13 | §2.1/§2.2.2/§2.3 failure-count and fragmentation prose | Move to Appendix F, keep Table 9 pointer. | 0.3 | none — 5.9 |
+
+**Would not move or cut, and why:**
+
+- **Figure 1** (pipeline + schema) and **§2.2 schema/model configuration** — the *originality* score rests entirely on the schema being legible; a reader cannot evaluate the contribution without it.
+- **§2.4 the nine enumerator constraints** (at least in condensed form, with Table 5 in appendix) — every reported chain number is unreadable without the length floor, the stop-at-first rule and the two gates. *Quality* depends on this.
+- **Table 7 (gate sensitivity)** and its two-sentence reading in §3.1 — this is the single control that keeps the chain-level numbers from being over-claimed. *Quality* drops if it moves out of body.
+- **§3.2 both audit runs' headline numbers** (0.6% / 18.1% and 26.4% / 21.7%) and the instrument explanation for the gap — the audit stage is half the contribution. *Quality and significance* both depend on it.
+- **§4.4 merge/centrality artifact with Figure 4** (headline only, details to Appendix H/I) — the most transferable methodological finding in the paper. *Significance* drops if cut.
+- **Table 16 arms A/E/F** at least as three sentences in §3.1 — the stage-name ablation is what distinguishes "extraction" from "schema filling." *Quality* drops if cut.
+- **Section P pointer** in the body (one sentence) — the failure mode is essential for honest reading of the release. *Ethics/limitations* adequacy depends on it.
+
+---
+
+## Questions
+
+1. **Release.** Can you supply an anonymized artifact link (graph dump, chain files, receipts, prompts) during the rebuttal? The paper's contribution is the release; a `[GAP: release URL]` in the submitted PDF is currently fatal. Resolving this is a precondition for any score above borderline.
+2. **One human arm.** Would you annotate a small stratified sample (20–30 documents, or the same 50 used for the κ arm) by hand against the judge's findings and report agreement? This is the single change most likely to raise my Quality score, because it would arbitrate the 0.6% / 18.1% / 26.4% / 28.8% spread rather than leaving four unreconciled instrument readings.
+3. **Spuriousness rate.** Section P shows one invented safety framing and Arm F shows 30% chain yield from sentence-shuffled text. What fraction of a random sample of, say, 50 released chains would an author label spurious in the Section P sense? Absent this number, a reader cannot judge whether the corpus is usable, and I would weight this above every graph statistic in the paper.
+4. **Reconciling the two audit runs.** The 0.6% → 26.4% jump is confounded by (a) document length and (b) the second run's extractions being rebuilt from the released graph without rationale fields. Re-running the *first* protocol on rationale-stripped rebuilds of the same 100 documents would isolate (b) at the cost of one batch call. Can you run it?
+5. **Any utility comparison at all.** Even a 20-query set with author-assigned relevance, comparing chain retrieval against embedding search over the same documents' abstracts, would convert Section 4.1 from anecdote into evidence. Would you attempt it, or alternatively expand the AI Safety Graph comparison in Section 5 (which is your strongest existing utility evidence) into a proper subsection?
+
+## Limitations
+
+Yes — the limitations discussion is more thorough and more self-critical than almost anything I review, and the Impact Statement's treatment of misattribution to identifiable authors, per-source licensing under ARD's MIT card, and the takedown route is genuinely well done. Two gaps remain: (i) no estimate of the rate of Section-P-style spurious chains in the release, which is the limitation a reuser most needs quantified; (ii) the `[GAP: compute acknowledgment — blocked on donor consent]` placeholder leaves the funding disclosure unresolved, which must be settled before publication.
+
+---
+
+## Scores
+
+- **Quality: 2** (fair). Methodologically careful and honest, but the central fidelity question is unanswered by design — four unreconciled LLM-internal omission estimates, no human anchor, no spuriousness rate, and the analysed unit selected by two attributes nothing validates.
+- **Clarity: 2** (fair). Well organized in outline and admirably explicit about populations, but ~50% over budget, heavily redundant across Introduction/Results/Limitations/Conclusion, and burdened by reader-instruction and aphorism where compression was needed.
+- **Significance: 2** (fair). The mechanism-indexed layer is a plausibly useful resource for the AI-safety literature and the construction-artifact findings transfer, but the corpus stops at 2023, the chain set is gate-contingent and run-unstable, the release is currently unavailable, and no utility measurement exists.
+- **Originality: 3** (good). The unit of analysis — a typed risk→intervention chain internal to one document — is a genuinely new framing relative to the ARD/AI Safety Graph/Atlas stack and to argument-mining and PICO extraction, and the paper positions itself against those literatures accurately. The mechanics (one schema-prompted call + cross-provider judge) are standard.
+- **Overall: 3** (Borderline reject). Reasons to accept: an honest, well-instrumented resource paper with transferable negative results and unusually complete reporting. Reasons to reject, which currently outweigh: no ground truth of any kind for the artifact's core property, no utility evidence, a release URL that does not exist in the submission, and a manuscript that is 50% over length with two use cases that are internal-audit history. A resolved release plus even a small human-annotated fidelity arm and a spuriousness rate would move me to 4, possibly 5.
+- **Confidence: 4.**

--- a/paper/reviews_2026-08-17/opus5_conference.meta.json
+++ b/paper/reviews_2026-08-17/opus5_conference.meta.json
@@ -1,0 +1,11 @@
+{
+  "provider": "anthropic",
+  "model": "claude-opus-5",
+  "mode": "conference",
+  "elapsed_sec": 161.3,
+  "response_chars": 18777,
+  "generated_utc": "2026-08-17T13:36:07+00:00",
+  "stop_reason": "end_turn",
+  "input_tokens": 91843,
+  "output_tokens": 10830
+}

--- a/paper/reviews_2026-08-17/opus5_workshop.md
+++ b/paper/reviews_2026-08-17/opus5_workshop.md
@@ -1,0 +1,128 @@
+# Review
+
+## Summary
+
+The paper contributes a two-stage LLM pipeline over the Alignment Research Dataset (ARD): (1) one schema-prompted `o3` call per document extracts a typed graph running from a named RISK to a proposed INTERVENTION through five intermediate reasoning stages (problem analysis → theoretical insight → design rationale → implementation mechanism → validation evidence), with per-edge confidence and per-intervention maturity/lifecycle; (2) a cross-provider judge (`claude-sonnet-4-5`) re-reads source + extraction and reports omissions, structural defects and proposed repairs, with three meta-graders on top. Applied to 11,779 documents it yields a 200,525-node graph and, after two LLM-assigned gates plus a sub-path collapse, 2,772 chains from 1,868 documents. The paper additionally reports a gate-sensitivity grid, a stage-label probe (98.8%), a cross-provider stage-agreement arm (κ=0.84), six ablation/degradation arms at n=20–30, and four "construction artifact" controls for clustering, centrality and co-occurrence analyses.
+
+## Strengths
+
+- **The task framing is correct and the gap is real.** Every existing resource over this literature (ARD, AI Safety Info, AI Safety Graph, AI Safety Atlas, MIT AI Risk Repository) indexes documents or names risks; none stores the risk→intervention argument. The comparison against the AI Safety Graph in §5 is the single most persuasive paragraph in the paper: on a paper list the authors did not choose, 40.4% chain yield independently reproduces their 40.5% arXiv figure, and 79 topic labels are contrasted with 325 risk–intervention pairs. That is a concrete demonstration of what the extra layer buys.
+- **Unusually disciplined self-auditing.** The gate-sensitivity grid (Table 7) is exactly the right instrument for a paper whose reporting unit is selected by two unvalidated model labels, and it distinguishes what the gates decide (yield 15.9%→99.4%, arXiv share 38.1%→15.0%) from what they do not (five-stage completeness within eight points). The four "true by design" statistics warning at the end of §4 and the merge/centrality artifact demonstration (Table 12, Figure 4) are the kind of negative methodological result that most dataset papers omit.
+- **The ablations answer the right question.** Arm E (stage names removed: chain yield 100%→36.7%, five-stage completeness →0%) is the control that turns "87.4% completeness" from evidence into schema-following, and the authors say so. Arm F (sentence-shuffled sources still yield 30% chains) is a genuinely useful upper bound on invention. Arm B/C/D justify full text, a reasoning model, and the stage vocabulary respectively.
+- **Reproducibility infrastructure is above the norm** for this kind of artifact: receipt files per claim, a claim→script→receipt map, prompts reproduced, the un-merged graph released so any gate setting is re-derivable.
+- **Appendix P (the Euclid failure case) is included rather than buried**, and the paper draws the correct lesson from it.
+
+## Weaknesses
+
+- **The central fidelity claim is unmeasured, and the paper says so four times without resolving it.** Three omission measurements span a factor of thirty (0.6% / 18.1% / 28.8%), a second run on the analysed population reads 26.4% / 21.7%, and none was adjudicated by a human. The authors' framing ("we report them all and reconcile none") is honest but leaves a prospective user of the release with no usable estimate of what fraction of a paper's argument the graph holds. A 20–30 document human-annotated arm — the same rubric, a human in place of the judge — would have cost days and would have anchored everything. Its absence is the paper's main technical gap.
+- **Precision against off-domain invention is never measured at all.** The judge instrument is about omission and structural integrity. Appendix P shows the pipeline manufacturing a safety framing ("prime scarcity affecting cryptographic key space") that its source never asserts, and this chain passes *every* filter the pipeline applies. Arm F puts a rate on a related phenomenon (30% of argument-destroyed documents still yield a gate-passing chain), which suggests the spurious-chain rate on real documents is not negligible. One manual pass over 50 chains scoring "is this chain a fair summary of an argument the paper makes?" is the missing number, and it is more decision-relevant for a reuser than any omission figure reported.
+- **The release is not verifiable.** The abstract contains a literal `[GAP: release URL — GitHub / Google Drive location to be inserted]`, and the acknowledgments and AI-assistance statement carry two more unresolved `[GAP: ...]` placeholders. For a paper whose stated contribution is a pipeline plus corpus, a reviewer cannot check the artifact exists in the form described. This is fixable, but as submitted the significance claim is unaudited.
+- **The retrieval use case has no evaluation.** Two hand-picked queries, no query set, no relevance judgements, no comparison to embedding search over abstracts. The paper concedes this. §4.1 therefore demonstrates that a path is *stored and addressable*, not that mechanism retrieval works better than reading the top-ranked documents.
+- **Corpus dates to 2023.** Median document year 2021; no post-2023 discourse. For a literature whose mechanism vocabulary changed sharply in 2024–25, the released corpus is of limited direct utility, and its main value is as a demonstration that the pipeline runs.
+- **The chain set is a heavily processed, venue-skewed slice.** Two unvalidated gates plus a 70%-containment collapse that loses 6.1% of nodes and 18.0% of distinct risk–intervention pairs, with arXiv admitted at 40.5% against LessWrong at 6.9%. The paper flags all of this correctly, but the net effect is that the object it analyses is not the object it releases, and the reader has to track twelve populations (Table 6) to keep straight which is which.
+- **Length and readability.** The main body is ~15 pages of dense, aphoristic prose with heavy cross-referencing and constant reader-direction. Several numbers are restated five or six times. Much of §3.2, §4.4–4.5, §2.5 and §6.1 is process history rather than result.
+
+---
+
+## Scores
+
+- **Quality: 3 (good).** Sound methods, strong sensitivity analysis and honest reporting; but the core fidelity claim is unvalidated, precision is unmeasured, several ablations run at n=20–30 against a shipped rather than fresh baseline, and a handful of numbers (merge sweep, hop growth, intake failure counts) are not re-derivable on the released substrate.
+- **Clarity: 2 (fair).** Organised, and every claim is traceable — but far too long, with a stylised voice that impedes rather than aids reading, unresolved TODO placeholders including one in the abstract, and heavy repetition of the same four percentages.
+- **Significance: 2 (fair).** Real gap, plausible utility, credible cross-check against the AI Safety Graph — but a 2023-bounded corpus, an unverifiable release, no retrieval baseline, and no precision estimate. Would move to 3 with a live artifact and a chain-level precision number.
+- **Originality: 3 (good).** The extract-and-audit pattern is standard; the causal-interventional stage schema as a domain-specific instance of argument mining over safety literature, and its systematic artifact analysis, are new and clearly positioned against argumentative zoning, PICO extraction and GraphRAG.
+- **Overall: 4 (Borderline accept)** at a workshop. Early, honestly reported, and highly discussable; the release and the missing human anchor are the things that keep it from higher.
+- **Confidence: 4.**
+
+---
+
+## 1. Unscientific / non-human / sloppy writing
+
+The manuscript has a consistent, recognisable stylistic tic: short aphoristic declaratives, sentence-length section headings that assert findings, and repeated instructions to the reader about how to read. Representative instances to revise:
+
+- Abstract: *"We report them all and reconcile none."* Rhetorical; states no result. Replace with the actual range and the reason they differ.
+- Abstract still contains `[GAP: release URL — GitHub / Google Drive location to be inserted]`. A submitted abstract must not contain a TODO.
+- §1: *"Two things follow for how the rest of this paper should be read, and we state them here. **What we release is the graph** … **What we analyse is an example**."* Meta-instruction to the reader in bold; compress to one sentence in Methods.
+- §3.2: *"Two sevens in this subsection are unrelated."* A coincidence of two integers promoted to a paragraph heading. Delete.
+- §3.2 heading: *"One evaluation design that answers nothing."* And *"One measurement artifact to separate before quoting any error rate."* Headings as slogans.
+- §2.3: *"A corpus of N short chains is exactly N components until something links them."* §3.2: *"The gap is an artifact of the instrument before it is anything else."* §4.4: *"That is the deeper reason the hub is an artifact."* Aphorism in place of statement.
+- §3.1: *"Where the two models disagree is more informative than that they mostly do not."* Inverted construction; several dozen similar.
+- Reader-imperatives throughout: *"Read the yield and mix figures as properties of the gate setting."*, *"Read those rows for portability rather than for capability."*, *"A reader should take the edge figure as the judge's opinion…"* Convert to declaratives.
+- Two further placeholders in Acknowledgments and one in "Use of AI Assistance" (*"[GAP: scope of the drafting claim — 'portions of this manuscript' stays imprecise until the co-authors confirm what each wrote by hand]"*). Editorial process notes visible in the submission; remove before any camera-ready.
+- Redundancy: the quartet 0.6% / 18.1% / 26.4% / 21.7% appears in the abstract, §1.1, §3.2 (twice), §6.1 and the conclusion. State once in Results, once in Limitations.
+- Appendix reference broken in §N: *"…are in experiment_review_grader_agreement_report.js**isn**The"* — text collides with the following sentence.
+
+## 2. Outsized importance attributed to non-load-bearing material
+
+The paper is commendably anti-hype (no "critical"/"essential" inflation), but a few claims are given weight they do not carry:
+
+- §2.7: *"the choice of extractor moves the bill by about a factor of five — **more than any other decision in the pipeline**."* Unsupported superlative: the gate setting moves yield by 6× and the corpus composition substantially, which is plainly a more consequential decision. Drop the comparative.
+- §1: *"the paired extract-and-audit design outlasts it"* — grand framing for one prompted call plus one judge call; the paper's own §3.2 shows the audit instrument is poorly matched to the thing it measures.
+- §4.4/Appendix H: *"That is the sense in which Section 4.4 calls its hub **manufactured**"* and the transitive-closure discussion is developed at length for an operation the authors **never applied** to the released graph. The finding is worth one paragraph, not a subsection plus an appendix plus a figure.
+- Appendix F: *"7 chains (0.3%), from 3 documents, originate from Google Docs."* Precision without purpose.
+- Table 7 caption: *"it is not the deployed maturity band, which Table 3 reserves for maturity 4."* Internal bookkeeping surfaced as if it were a caveat a reader needs.
+
+## 3. Sausage-making to cut
+
+Each of the following reports a process failure or an internal history with no load-bearing consequence for the paper's claims.
+
+| Item | Where | What to do |
+|---|---|---|
+| Pre/post-repair grader scoring, explicitly confounded and drawing no conclusion | §3.2 "One evaluation design that answers nothing"; Table 6 row "Scored before/after repairs (95, 95, 13)"; Appendix N "Grader agreement" | **Delete** the paragraph, the table row and the appendix paragraph. Keep one sentence in Limitations: "we ran an unblinded pre/post repair scoring and discard it." |
+| Meta-grader session mechanics: interactive agent sessions, drifting output schema, uneven denominators | §2.6, §2.7, Appendix B | **Cut to a footnote.** The only consequence a reader needs is that the error profile covers 43 of 100 papers. |
+| Race-framing non-reproduction from an *earlier internal pass* (88%→2.6%, 44×→2.0×, "51 disconnected"→"2") | §4.5 + Appendix M classifier validation | **Compress to three sentences** stating the control ("report full-population prevalence beside any selected-head statistic; choose the unit explicitly"). The forensic reconstruction of a superseded internal finding is not a result. Appendix M can go entirely. |
+| Merge-threshold sweep run on a different, superseded 200,061-node substrate | Appendix H, §2.2 ("an earlier internal pass … a similarity layer roughly 8.5× sparser") | **Delete the earlier-substrate history**; keep the operating point and the recall gap (4,411 vs 77,759 candidate pairs), which *is* load-bearing. |
+| Sub-path collapse forensics: 21.7% chords, 78.3% touch a foreign node, 579 lost pairs, 1,169 orphaned nodes, threshold sweep 2,658→5,460 | §2.5 "What the step drops" | **Move to appendix**, keep two numbers in the main text (6.1% node loss, 18.0% pair loss). |
+| Token-bill reconstruction from surviving artifacts, plus repricing across hypothetical models | §2.7 | **Move to appendix.** Keep: one call per document, 122.4M input tokens, USD 32–118/1,000 docs. The archaeology of the lost logs is not a finding. |
+| "Two sevens are unrelated" | §3.2 | **Delete.** |
+| Schema-version rationale-field mismatch accounting for 84% of blocker flags | §3.2, Appendix N | **Compress to one sentence** and move the counts to the appendix. |
+| §2.1 provenance confession that three failure counts are "quoted from the project's own packaging record" and not re-derivable | §2.1 | Keep one clause; the current paragraph is longer than the fact warrants. |
+
+## 4. Length triage: 15 pages → 10
+
+Ordered by pages recovered per unit of score risk; running total in the right column.
+
+| # | Item | Move / delete | Why | Pages | Running | Score effect |
+|---|---|---|---|---|---|---|
+| 1 | §4.5 framing-analysis narrative (non-reproducing earlier finding) | Appendix (already has M) | Only load-bearing content is the two-sentence control | 0.30 | 0.30 | none |
+| 2 | §3.2 "One evaluation design that answers nothing" + "One measurement artifact" paragraphs | Delete / one sentence each | Confounded design, and a schema-version bookkeeping note | 0.35 | 0.65 | none |
+| 3 | §2.5 "What the step drops" forensics | Appendix | Two numbers suffice in main text | 0.35 | 1.00 | none |
+| 4 | §2.7 token-bill reconstruction + cross-model repricing | Appendix | Keep three sentences of cost | 0.50 | 1.50 | none |
+| 5 | Figure 4 (two-panel merge star) | Appendix | Table 12 already quantifies the artifact; the figure is decorative | 0.45 | 1.95 | none |
+| 6 | §1.1 "Research Goals" bullets | Delete | Verbatim restatement of abstract + §1 | 0.35 | 2.30 | none |
+| 7 | §1 "Two things follow for how this paper should be read" | Delete | Meta-instruction; one clause in §2 covers it | 0.20 | 2.50 | none |
+| 8 | §5 GraphRAG + hypothesis-generation paragraphs | Compress by half | Positioning against safety resources and argument mining is what matters | 0.40 | 2.90 | none |
+| 9 | §2.3 structural diagnostics of concatenated graph | Appendix F | Arithmetic consequence, stated twice already | 0.15 | 3.05 | none |
+| 10 | §2.1/§2.2.2 extraction-failure accounting | Compress | Keep "86.4% reach the graph; failures are mostly empty bodies" | 0.20 | 3.25 | none |
+| 11 | §4.3 clustering narrative | Compress to control + one number | Appendices J/K carry it | 0.25 | 3.50 | none |
+| 12 | §3.1 probe details (TF-IDF ladder, centroid margins, per-pair error counts) | Appendix G | Keep 98.8% vs 20%, κ=0.84, and the theoretical-insight weakness | 0.60 | 4.10 | minor |
+| 13 | §6.1 Limitations, compress by ~half (esp. "Single extractor and run-to-run floor") | Compress; Table 16 carries the numbers | Currently ~2 pages restating §3 | 1.00 | **5.10 ← target reached** | minor (limitations completeness) |
+| 14 | Impact statement, compress | — | Keep misattribution + takedown + licensing, one paragraph each | 0.30 | 5.40 | none |
+| 15 | Figure 3B (maturity × confidence heatmap) | Appendix | §4.2 gives the composition in text | 0.20 | 5.60 | minor |
+
+**Would not move or cut, and which score depends on it:**
+
+- **Table 7 (gate-sensitivity grid) and the §3.1 paragraph reading it.** Quality. Without it, every chain-level number is an unqualified artifact of two unvalidated labels.
+- **§2.2 schema + rubrics and §2.4 gate definitions** (Table 5 may stay in the appendix, but the four attribute gates must be in the body). Quality, reproducibility.
+- **Table 6 (twelve populations).** Clarity and quality jointly — it is the only thing that prevents the reader from conflating audited, analysed and released populations.
+- **§3.2 both omission runs (0.6/18.1 and 26.4/21.7) and the instrument explanation.** Quality; also the paper's chief honesty credit.
+- **§3.1 ablation summary (arms E and F headline numbers) and Table 16.** Quality and originality: arm E is what converts 87.4% completeness from a claim into a measured schema effect.
+- **Appendix P failure case and its pointer in §4/§6.1.** Quality/limitations.
+- **§5 paragraph 1–2 (safety-resource landscape + the AI Safety Graph cross-check).** Originality and significance: this is the only external validation in the paper.
+- **One example chain from Table 1** (halve to a single block). Significance: the paper needs one concrete instance of its output in the body.
+- **A working release URL and licence statement.** Significance; currently a placeholder.
+
+---
+
+## Questions for the authors
+
+1. **Human anchor.** Would you run even a small human-annotated arm (20–30 documents, the same rubric, a human in place of the judge) and report agreement against it? This is the single change that would most raise my quality and significance scores: it would convert the 0.6%/18.1%/26.4%/28.8% spread from four unadjudicated model opinions into a bounded estimate. If infeasible before camera-ready, please state explicitly in the abstract that no fidelity rate is established.
+2. **Chain-level precision.** Appendix P shows a chain that is spurious yet passes every filter, and arm F shows 30% of argument-destroyed documents still yield gate-passing chains. What fraction of the 2,772 released chains would a human call a fair summary of an argument the source makes? A manual pass over 50 sampled chains, reported with a confidence interval, would be decisive for whether the artifact is reusable. Without it, a reader cannot distinguish "partial record" from "sometimes fabricated record."
+3. **Release.** Please confirm the artifact (FalkorDB dump, prompts, enumerator, 8,954/2,772 path files, receipts) is available at an anonymised URL for review, and state the licence. As submitted the abstract carries a placeholder; I cannot verify the contribution.
+4. **Retrieval baseline.** Would you add a minimal comparison — 20 risk–intervention queries, relevance judgements from one annotator, your chain lookup against embedding retrieval over abstracts? Even a weak result here would substantiate the paper's motivating claim that document indices cannot serve this query.
+5. **Recommended operating point.** Given Table 7, which gate setting do you recommend to a reuser, and would you ship chain sets at more than one setting (e.g. ≥3/≥3 and ≥2/≥2) so that the venue skew is a user choice rather than yours?
+
+## Limitations
+
+Yes — and unusually thoroughly. §6.1 states the sample size of the audit, the unvalidated gates, the LLM-internal validation chain, the n=30 ablation scale, the missing retrieval baseline, the run-to-run instability of node identity and gate membership, and the 2023 corpus boundary; the impact statement addresses misreading, misattribution to identifiable authors (with a takedown route), licensing, and dual use.
+
+Two gaps worth adding: (i) there is no limitation naming the absence of any **precision / spurious-chain rate**, which is the failure mode Appendix P exhibits and the judge protocol does not measure; the limitations section discusses omission at length and invention only glancingly. (ii) The three `[GAP: ...]` placeholders (release URL, acknowledgment, drafting scope) must be resolved; the AI-assistance statement as written does not actually disclose the scope of LLM drafting.

--- a/paper/reviews_2026-08-17/opus5_workshop.meta.json
+++ b/paper/reviews_2026-08-17/opus5_workshop.meta.json
@@ -1,0 +1,11 @@
+{
+  "provider": "anthropic",
+  "model": "claude-opus-5",
+  "mode": "workshop",
+  "elapsed_sec": 183.7,
+  "response_chars": 20455,
+  "generated_utc": "2026-08-17T13:36:29+00:00",
+  "stop_reason": "end_turn",
+  "input_tokens": 91920,
+  "output_tokens": 12623
+}

--- a/paper/section_cut_list.md
+++ b/paper/section_cut_list.md
@@ -1,0 +1,168 @@
+# Paper A — consolidated cut list, to reach a 10-page main body
+
+**Built 2026-08-17** from the six-review round in `paper/reviews_2026-08-17/` (Claude Opus 5,
+GPT-5.6 Sol, Gemini 3.1 Pro; conference and workshop bars). Each model saw only the compiled
+PDF, the NeurIPS scoring guidance and the prompt — no repo context. The prompt carried a
+fourth item this round asking each reviewer to name the material whose removal is least
+likely to move its own scores, with per-item page estimates and a running total. Script:
+`paper/review_multi_model.py`; receipts `<model>_<mode>.md` + `.meta.json`.
+
+🔴 **This file is the cut list only.** Everything else — studies, decisions, the reviewer
+register — stays in `paper/OPEN_ITEMS.md`. Do not start a second open-items list here.
+
+## The measured starting point, which is worse than the estimate on record
+
+`AISafetyIntervention_PaperA_shared_long.pdf`, 27 pages, 1.37 MB, compiled 2026-08-17.
+Measured with PyMuPDF: the body runs pages 1 to 15, References begins 89% down page 15, and
+the appendices occupy pages 16 to 27. **Main body excluding references is therefore ~14.9
+pages, and the gap to close is ~5 pages, not the ~3 that `OPEN_ITEMS.md` carries.** That
+entry was explicitly a character-count heuristic with an instruction to compile and read the
+real number; this is the real number. All six reviewers independently read the body as
+"roughly 15 pages", so the target in the prompt was not leading them.
+
+## Scores this round, against the 2026-08-15 round
+
+| Model | Conference | vs 08-15 | Workshop | vs 08-15 |
+|---|---|---|---|---|
+| Claude Opus 5 | 3 borderline reject | = | 4 borderline accept | = |
+| GPT-5.6 Sol | 3 borderline reject | **+1** | 4 borderline accept | **+1** |
+| Gemini 3.1 Pro | **5 accept** | **+2** | 5 accept | = |
+
+The evidence added between the two rounds (#165, #166, #168, #171, #172) moved two of the
+three models and neither of the two that moved cited anything else as the reason. Conference
+is still not viable on two of three; workshop is 4/4/5 and is the defensible target.
+
+## The consolidated cut table
+
+Votes are over the six reviews (OC/OW = Opus conference/workshop, GC/GW = GPT-5.6 Sol,
+MC/MW = Gemini). Pages are the reviewers' own estimates; where they bundled items the bundle
+is split proportionally and marked. "Keep-collision" flags a row that touches the
+explicit-keep list of `OPEN_ITEMS.md` (R121-R126) and states how the collision resolves.
+
+| # | Item | Where | Action | Votes | Pages (median) | Keep-collision |
+|---|---|---|---|---|---|---|
+| 1 | Limitations, compressed to ~0.8 pp — one paragraph per distinct limitation, no re-derivation of numbers already in tables | `sec:limitations` | compress | 5/6 (OC OW MC MW GW) | **1.1** (1.0-1.5) | none. Every reviewer that names it also says the *content* is a credit; the objection is that it restates §3 |
+| 2 | Merge/centrality derivation + Figure 2 (the two-panel hub) + the ANN candidate-recall paragraph | `sec:r-hub`, `fig:hub` | move to appendix, keep the headline and the control inline | 6/6 | **0.9** (0.45-1.45) | **R121.** Resolves: all six keep the 90x finding and its control in the body; only the derivation, the four-condition detail and the figure move |
+| 3 | Probe decomposition, second-annotator per-stage confusion, arm-by-arm ablation detail | `sec:r-stages` | move to appendix (G, C, ablation) | 5/6 (OC OW MW GC GW) | **0.9** (0.5-0.9) | **R122-adjacent.** Resolves: keep 98.8% vs 20%, kappa 0.84, arm E and arm F headlines, and `tab:gates` inline |
+| 4 | Framing analysis, the race-framing non-reproduction | `sec:r-selection` | **delete**; the control survives as two sentences under `sec:r-hub` | 6/6 | **0.55** (0.3-0.65) | none. Called "postmortem of an unpublished internal result" by four of six |
+| 5 | The confounded pre/post repair design, "Two sevens in this subsection are unrelated", the schema-mismatch paragraph, and the three-omission prose that duplicates `tab:omission` | `sec:r-judge` | **delete**; one sentence in Limitations | 6/6 | **0.5** (0.35-0.65) | none. Unanimous in this round and in the 08-15 round |
+| 6 | Token-bill reconstruction and the cross-model repricing band | `sec:m-repro` | move to appendix; keep one sentence (one call per document, 122.4M input, USD 32-118/1,000) | 4/6 (OC OW GC GW) | **0.5** (0.45-0.55) | none |
+| 7 | Clustering narrative, the UMAP-vs-original-space silhouette argument | `sec:r-clustering` | compress to the control plus one number, detail to `app:clustering` | 6/6 | **0.45** (0.25-0.55) | **R126.** Resolves: the one clean same-space comparison stays as a sentence; the argument moves |
+| 8 | "What the step drops" — chords, 78.3%, 579 pairs, threshold sweep | `sec:m-reporting` | move to appendix; keep 6.1% node loss and 18.0% pair loss inline | 6/6 | **0.4** (0.3-0.5) | none. Every reviewer insists the two headline losses stay in the body |
+| 9 | "Two things follow for how the rest of this paper should be read" + the `sec:goals` bullets that restate the abstract | `sec:intro`, `sec:goals` | delete | 2/6 as a page item, **6/6 as a style flag** | 0.55 (0.2-1.0) | none |
+| 10 | Intake / failure-count / structural-diagnostics prose | `sec:m-corpus`, `sec:m-recovery`, `sec:m-structural` | move to `app:composition` | 3/6 (OC OW GC) | 0.35 (0.15-0.7) | none |
+| 11 | Related Work: GraphRAG and hypothesis-generation paragraphs | `sec:related` | compress by half | 2/6 (OC OW) | 0.38 | **Inverse collision:** OC wants the AI Safety Graph paragraph *lengthened*; it is the only external validation in the paper |
+| 12 | Second retrieval example (Query 2, Ngo et al.) | `tab:query` | move to appendix, keep one worked query | 2/6 (OC MC) | 0.33 | five of six require at least one example to stay |
+| 13 | Judge recovery of failed extractions, 23 of 441 | `sec:m-recovery` | move to appendix | 2/6 (GC GW) | 0.2 | matches R82 from the 08-15 round (2/3 then) |
+| 14 | Figure 1 panel B (maturity x confidence) | `fig:dataset` | move to appendix | 1/6 (OW) | 0.2 | do not act on one vote |
+| 15 | Impact Statement, compressed | `sec:impact` | compress | 1/6 (OW) | 0.3 | GC/GW both list it as un-cuttable. **Do not act** |
+| 16 | Arm G (reference-list-only) and arm D (flat triples) | `app:ablation` | delete | 1/6 (GC) | 0.1 | contradicted by four reviewers who cite arm G as evidence. **Do not act** |
+
+## The package that closes the gap
+
+Rows 1-8, every one of them at 4/6 agreement or better, and none of them touching a claim:
+
+| Row | Item | Pages | Running |
+|---|---|---|---|
+| 5 | `sec:r-judge` confounded design + editorial paragraphs, deleted | 0.50 | 0.50 |
+| 4 | `sec:r-selection` deleted, control preserved | 0.55 | 1.05 |
+| 8 | `sec:m-reporting` collapse forensics to appendix | 0.40 | 1.45 |
+| 7 | `sec:r-clustering` compressed | 0.45 | 1.90 |
+| 6 | `sec:m-repro` cost reconstruction to appendix | 0.50 | 2.40 |
+| 2 | `sec:r-hub` derivation + Figure 2 to appendix | 0.90 | 3.30 |
+| 3 | `sec:r-stages` probe/agreement/ablation detail to appendix | 0.90 | 4.20 |
+| 1 | `sec:limitations` compressed to ~0.8 pp | 1.10 | **5.30** |
+
+Row 9 (0.55) and row 10 (0.35) are the buffer if the estimates run optimistic, and both are
+free: row 9 is a style fix every reviewer asked for independently, and row 10 is
+reproducibility detail nobody defends.
+
+**Nothing in this package requires cutting the three use cases wholesale**, which is what
+`OPEN_ITEMS.md` listed first by yield and last by preference and which was flagged as a
+co-author's call. Rows 2 and 7 move the derivations and keep each finding with its control
+inline — the shape the June outline already specified.
+
+## Explicitly do not move or cut
+
+Union of the six "would refuse" lists, with the score each reviewer attached:
+
+| Item | Named by | Score at risk |
+|---|---|---|
+| Figure 4 (pipeline + schema) and `sec:m-extraction` | 6/6 | Originality, Clarity |
+| `tab:gates` and the paragraph reading it | 6/6 | Quality — "every chain-level number is unreadable without it" |
+| Both audit runs' headline numbers and the instrument explanation | 6/6 | Quality; also the paper's main honesty credit |
+| Arm E and arm F headlines (`tab:ablation`) | 6/6 | Quality, Originality — arm E is what converts 87.4% from claim to measured schema effect |
+| `app:failure` (the Euclid chain) and its body pointer | 6/6 | Quality, limitations adequacy |
+| At least one chain from `tab:query` | 5/6 | Significance — "without it the paper builds a dataset and never shows it can be used" |
+| `tab:populations-master` | 3/6 (OC OW GC) | Clarity and Quality jointly |
+| The nine enumerator constraints, at least in condensed form | 3/6 (OW GC GW) | Quality, reproducibility |
+| The AI Safety Graph comparison (#166) | 2/6, and OC wants it *expanded* | Originality, Significance — the only external validation |
+| A working release URL and the licence pair | 6/6 | Significance; currently a rendered placeholder |
+
+## Not cuts — issues this round raised that are new to the register
+
+None of these is a length item, and three of them are cheap. Ranked by what a reviewer does
+with them.
+
+1. 🔴 **Stage order is not enforced and traversal is undirected, so a "chain" may not be a
+   directed argument** (GC, GW; both make it score-moving, GC says a bad result would take it
+   to 2). Verified against `app:cuts`: monotonic stage order is not among the ten constraints,
+   and "edge direction ignored" is row 10. The asks are all Class B over the released path
+   file: the share of chains with monotonic stage order, the share whose edges are all
+   traversed with their stored orientation, and the counts under directed traversal. **Cheap,
+   and the paper cannot answer it today.**
+2. 🔴 **The omission denominators are misaligned with their instruments** (GC, GW). Within the
+   coverage list the missing share is 302/777 = 38.9%, and on the second run 476/627 = 75.9%;
+   the paper divides by released edges instead and prints 18.1% and 21.7%. The 38.9% already
+   exists in a source comment at the abstract and in `app:judge` as "42.2% of rows were
+   covered", but no body sentence carries it as a rate. Both reviewers also reject
+   `tab:omission`'s "upper bounds on omission" wording, since an unadjudicated judge can miss
+   omissions as well as invent them. **Wording plus one table column; no new inference.**
+3. 🔴 **`sec:r-judge` prints "777 rows --- 328 covered, 146 partially covered, 302 missing",
+   which sums to 776** (GW). Verified in the receipt: the 777th row is
+   `unlabelled_or_other = 1`, a "covered abstractly" status. One clause fixes it. A reviewer
+   who checks the arithmetic and finds it wrong discounts every other number.
+4. **"The stage we audit is the stage we ship" is in tension with `app:judge`** (GW), which
+   says the judge audited pre-ingestion extraction JSON whose defect classes do not reach the
+   released graph, and whose re-serialised edge count (10.8/paper) is well below the released
+   one (16.7). Both statements are in the manuscript and both are true; the framing sentence
+   needs the qualifier, or the tension reads as a contradiction.
+5. **No precision or spurious-chain rate anywhere** (OC, OW, and implied by GC/GW). The
+   sharpest form: *what share of 50 randomly sampled released chains would an author call
+   spurious in the Euclid sense?* OC calls this the number it would weight above every graph
+   statistic in the paper. This is the S4-shaped human item the team decided not to do,
+   restated at n=50 and on precision rather than omission — and unlike the S4 design it does
+   not need the annotator to reproduce a chain, only to judge one, which is minutes rather
+   than three hours per paper. **Worth reopening the S4 decision for this one variant.**
+6. **"122.4M input tokens" is called measured and is reconstructed** (GW): logs did not
+   survive, retries and failed records are excluded, visible output is calibrated from one
+   response. The manuscript says all of this in `sec:m-repro`; the abstract does not. Retitle
+   as a reconstructed nominal estimate in the abstract.
+7. **"Scalable" in the title is established for extraction only** (GC): the judge ran at
+   sample scale, similarity construction can be quadratic, and the paper's own #168 follow-up
+   shows path enumeration exploding with mean degree. Either scope the claim or measure the
+   other three stages.
+
+Items 1, 2, 3, 4 and 6 are all corrections rather than experiments. Item 1 is one Class B
+script. Item 5 is the only one needing a person.
+
+## Style, restated because it is now unanimous
+
+Every one of the six flagged the same register, and four flagged the same three sentences:
+"We report them all and reconcile none" (abstract), "One evaluation design that answers
+nothing" (`sec:r-judge` heading), and "Two sevens in this subsection are unrelated". Rows 5
+and 9 of the cut table remove two of the three. The general fix all six converge on: convert
+finding-as-sentence headings to noun phrases, delete reader-instruction ("Read those rows
+for portability rather than for capability"), and state each caveat once. This is L2/L3/L6 in
+`OPEN_ITEMS.md`, which recorded L3 as partial; the external round says the residue is still
+the dominant impression the prose leaves.
+
+Two reviewers separately noted that the density of parallel constructions reads as
+machine-drafted. Neither concluded the content was generated; both said it costs credibility.
+
+## Provenance
+
+Six jobs, all completed, no truncation: 307,854 input and 57,829 output tokens total,
+4.7 minutes wall-clock for the slowest. Per-job usage in the `.meta.json` files. The
+prompt change is the fourth item added to `PROMPT_CONFERENCE`, which the workshop mode
+inherits by concatenation, so both bars answered the same length question.


### PR DESCRIPTION
Closes #173. Also carries the 2026-08-17 review round and the cut list built from it.

Branches off `study/multimodel-consistency` (#170), so merging this merges that stack. Base is set accordingly. Review in number order.

## 1. The review round, and it moved the scores

Six jobs, three models x two bars, on the current 27-page build. `paper/review_multi_model.py` gained a fourth prompt item asking each reviewer to name the material whose removal is least likely to change the scores it just gave, with per-item page estimates and a running total. Receipts in `paper/reviews_2026-08-17/`, six `.md` + six `.meta.json`.

| model | conference | vs 08-15 | workshop | vs 08-15 |
|---|---|---|---|---|
| Claude Opus 5 | 3 borderline reject | = | 4 borderline accept | = |
| GPT-5.6 Sol | 3 borderline reject | **+1** | 4 borderline accept | **+1** |
| Gemini 3.1 Pro | **5 accept** | **+2** | 5 accept | = |

Two of three rose, and neither cited anything but the evidence added since 08-15 (#165, #166, #168, #171, #172). Conference is still not viable on two of three; workshop is the defensible target.

**What caps the two that sit at borderline accept is not length.** Both name the same two things and both state the score: the rendered release-URL placeholder, and the absence of any human-anchored precision number. Length costs Clarity, not Overall.

## 2. `paper/section_cut_list.md`

Sixteen candidate items with per-reviewer votes, page estimates, and a flag where a row collides with the standing keep-list. The eight at 4/6 or better sum to **5.30 pages**, which closes the gap without cutting the three use cases wholesale -- the option the open-items list ranked first by yield and last by preference. Two further rows are free buffer.

**The gap was two pages larger than the record said.** Measured on the PDF with PyMuPDF: 27 pages, body pp.1-15, References beginning 89% down page 15, appendices pp.16-27, so the main body is ~14.9 pages against a stated ~12.5-13. That entry was explicitly a character-count heuristic with an instruction to compile and read the real number.

## 3. The study: `experiment_review_chain_order_semantics.py`

Full numbers and the two secondary findings are in #173. Headline, over the reporting unit: **84.6%** monotonic stage order, **72.0%** strictly increasing, **80.6%** of chains walked entirely with the grain of their own edges, 800 of 17,829 hops against it, 0 hops unmatched. The raw set is 66.2% and 62.7%, so the sub-path collapse raises order-conformance by 18 points as a side effect nobody designed.

It also corrects `sec:m-paths`: relation types are mixed as relations, but each of the five with more than 25,000 instances ascends the logical chain in 98.9-99.7% of cases, so "mixed in orientation" did not justify an undirected traversal. A directed enumeration was available and would have kept four chains in five.

## 4. Manuscript, pushed to `AISafetyIntervention_PaperA_shared@ac7b29f`

- Nine red `\CUTNOTE{}` blocks beside the section titles the round wants moved, deleted or compressed, each carrying its vote count and page estimate. **Nothing is cut.** The token is `[CUT-REVIEW:`, not `[GAP:`, so texlint's open-item count stays a count of team decisions -- 14, of which 4 render. One grep for `CUTNOTE` strips the scaffold.
- `sec:m-paths` and `tab:cuts` carry the order/orientation measurement.
- **The 777 sum.** `328 + 146 + 302` read as an arithmetic error against a stated 777; the fourth status, one relationship the judge marked covered only in the abstract, was never printed. Fixed in `sec:r-judge` and `app:judge`.
- **Both coverage denominators now print.** 18.1% of released edges and 38.9% of the judge's own expected list on the first run; 21.7% and 75.9% on the second. Neither is recall, nothing enumerates what a source supports, and `tab:omission` no longer calls them upper bounds -- an unadjudicated judge can miss omissions as easily as propose unsupported ones.
- **"The stage we audit is the stage we ship" gained the qualifier it needed.** Same population, one step upstream in representation: the judge reads the extraction JSON, and `upsert_edge` runs `MATCH (a {name}), (b {name})` before `MERGE`, so an edge naming an unlisted node is dropped rather than repaired. The candidate explanation "we only judged 100 papers" is wrong and is flagged as such in a source comment -- the integrity check runs over the whole 200,525-node graph.

## Verification

- `experiment_paper_claim_audit.py` -> **378/378 PASS, 0 FAIL** (355 -> 378; +23 for the two coverage denominators, the chain-order figures and a band check that cannot silently widen to include `enabled_by` at 90.8%).
- `experiment_paper_finding_coverage.py` -> 60/60 findings present, 10/10 retired phrasings absent, 0 self-consistency problems.
- `asciify_tex.py` pure ASCII, `texlint.py` 0 blocking.
- One correction rides along: the "94.1% of hops match a directed edge" comment in `experiment_review_containment_semantics.py` does not reproduce and had reached the body of #157. Reproducible figures are 92.1% (raw instances) and 95.5% (reporting unit); 94.6% is the distinct-pair version. Do not cite 94.1%.
